### PR TITLE
fix(onboarding): validate profile before signup, share the rules

### DIFF
--- a/api.md
+++ b/api.md
@@ -99,7 +99,12 @@ Vérifie si l'onboarding initial a été complété. **`completed` est stricteme
 
 // Response 200
 { ...same as GET /api/me }
+
+// Error 400 (un ou plusieurs champs invalides)
+{ error: { code: "VALIDATION_ERROR", message: "..." } }
 ```
+
+> **Validation du trio nom/pseudonyme** (règles partagées via `src/shared/profile-validation.ts`, communes à `PATCH /api/me` et `POST /api/onboarding/profile`) : `firstName` / `lastName` <= 100 caractères, `pseudonym` entre 2 et 30 caractères et limité à `[a-zA-Z0-9_-]`. Les valeurs sont trimées avant écriture. `PATCH /api/me` est partiel : aucun champ n'est requis, mais tout champ présent et non vide est validé avec ces mêmes règles (un `pseudonym` d'un seul caractère est donc rejeté ici aussi). Le signup (`POST /api/onboarding/profile`) exige en plus `firstName` + `pseudonym` non vides.
 
 ### `POST /api/me/avatar`
 

--- a/src/client/lib/profile-validation-i18n.ts
+++ b/src/client/lib/profile-validation-i18n.ts
@@ -1,0 +1,31 @@
+/**
+ * Map shared profile validation issue codes to localized strings.
+ *
+ * Keeps the codes -> i18n key mapping in one place so both signup call sites
+ * (StepIdentity, InvitePage) render the same messages.
+ */
+import type { TFunction } from 'i18next'
+import {
+  MAX_NAME_LENGTH,
+  MAX_PSEUDONYM_LENGTH,
+  type ProfileErrorCode,
+} from '@/shared/profile-validation'
+
+export function translateProfileErrorCode(t: TFunction, code: ProfileErrorCode): string {
+  switch (code) {
+    case 'first_name_empty':
+      return t('validation.profile.firstNameEmpty')
+    case 'first_name_too_long':
+      return t('validation.profile.firstNameTooLong', { max: MAX_NAME_LENGTH })
+    case 'last_name_too_long':
+      return t('validation.profile.lastNameTooLong', { max: MAX_NAME_LENGTH })
+    case 'pseudonym_empty':
+      return t('validation.profile.pseudonymEmpty')
+    case 'pseudonym_too_short':
+      return t('validation.profile.pseudonymTooShort')
+    case 'pseudonym_too_long':
+      return t('validation.profile.pseudonymTooLong', { max: MAX_PSEUDONYM_LENGTH })
+    case 'pseudonym_invalid_chars':
+      return t('validation.profile.pseudonymInvalidChars')
+  }
+}

--- a/src/client/locales/de.json
+++ b/src/client/locales/de.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Aktualisierung"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "Vorname ist erforderlich",
+      "firstNameTooLong": "Vorname muss weniger als {{max}} Zeichen haben",
+      "lastNameTooLong": "Nachname muss weniger als {{max}} Zeichen haben",
+      "pseudonymEmpty": "Pseudonym ist erforderlich",
+      "pseudonymTooShort": "Pseudonym muss mindestens 2 Zeichen haben",
+      "pseudonymTooLong": "Pseudonym muss weniger als {{max}} Zeichen haben",
+      "pseudonymInvalidChars": "Pseudonym darf nur Buchstaben, Zahlen, Unterstriche und Bindestriche enthalten"
+    }
   }
 }

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Update"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "First name is required",
+      "firstNameTooLong": "First name must be under {{max}} characters",
+      "lastNameTooLong": "Last name must be under {{max}} characters",
+      "pseudonymEmpty": "Pseudonym is required",
+      "pseudonymTooShort": "Pseudonym must be at least 2 characters",
+      "pseudonymTooLong": "Pseudonym must be under {{max}} characters",
+      "pseudonymInvalidChars": "Pseudonym can only contain letters, numbers, underscores, and hyphens"
+    }
   }
 }

--- a/src/client/locales/es.json
+++ b/src/client/locales/es.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Actualizar"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "El nombre es obligatorio",
+      "firstNameTooLong": "El nombre debe tener menos de {{max}} caracteres",
+      "lastNameTooLong": "El apellido debe tener menos de {{max}} caracteres",
+      "pseudonymEmpty": "El seudónimo es obligatorio",
+      "pseudonymTooShort": "El seudónimo debe tener al menos 2 caracteres",
+      "pseudonymTooLong": "El seudónimo debe tener menos de {{max}} caracteres",
+      "pseudonymInvalidChars": "El seudónimo solo puede contener letras, números, guiones bajos y guiones"
+    }
   }
 }

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Mise à jour"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "Le prénom est obligatoire",
+      "firstNameTooLong": "Le prénom doit comporter moins de {{max}} caractères",
+      "lastNameTooLong": "Le nom doit comporter moins de {{max}} caractères",
+      "pseudonymEmpty": "Le pseudonyme est obligatoire",
+      "pseudonymTooShort": "Le pseudonyme doit comporter au moins 2 caractères",
+      "pseudonymTooLong": "Le pseudonyme doit comporter moins de {{max}} caractères",
+      "pseudonymInvalidChars": "Le pseudonyme ne peut contenir que des lettres, des chiffres, des tirets bas et des traits d’union"
+    }
   }
 }

--- a/src/client/locales/it.json
+++ b/src/client/locales/it.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Aggiorna"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "Il nome è obbligatorio",
+      "firstNameTooLong": "Il nome deve contenere meno di {{max}} caratteri",
+      "lastNameTooLong": "Il cognome deve contenere meno di {{max}} caratteri",
+      "pseudonymEmpty": "Lo pseudonimo è obbligatorio",
+      "pseudonymTooShort": "Lo pseudonimo deve contenere almeno 2 caratteri",
+      "pseudonymTooLong": "Lo pseudonimo deve contenere meno di {{max}} caratteri",
+      "pseudonymInvalidChars": "Lo pseudonimo può contenere solo lettere, numeri, trattini bassi e trattini"
+    }
   }
 }

--- a/src/client/locales/ja.json
+++ b/src/client/locales/ja.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "更新"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "名は必須です",
+      "firstNameTooLong": "名は{{max}}文字未満にしてください",
+      "lastNameTooLong": "姓は{{max}}文字未満にしてください",
+      "pseudonymEmpty": "ニックネームは必須です",
+      "pseudonymTooShort": "ニックネームは2文字以上にしてください",
+      "pseudonymTooLong": "ニックネームは{{max}}文字未満にしてください",
+      "pseudonymInvalidChars": "ニックネームには英数字、アンダースコア、ハイフンのみ使用できます"
+    }
   }
 }

--- a/src/client/locales/pl.json
+++ b/src/client/locales/pl.json
@@ -3755,5 +3755,16 @@
   },
   "topbar": {
     "updateAvailable": "Aktualizuj"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "Imię jest wymagane",
+      "firstNameTooLong": "Imię musi mieć mniej niż {{max}} znaków",
+      "lastNameTooLong": "Nazwisko musi mieć mniej niż {{max}} znaków",
+      "pseudonymEmpty": "Pseudonim jest wymagany",
+      "pseudonymTooShort": "Pseudonim musi mieć co najmniej 2 znaki",
+      "pseudonymTooLong": "Pseudonim musi mieć mniej niż {{max}} znaków",
+      "pseudonymInvalidChars": "Pseudonim może zawierać tylko litery, cyfry, podkreślenia i myślniki"
+    }
   }
 }

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "Atualizar"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "O nome é obrigatório",
+      "firstNameTooLong": "O nome deve ter menos de {{max}} caracteres",
+      "lastNameTooLong": "O sobrenome deve ter menos de {{max}} caracteres",
+      "pseudonymEmpty": "O pseudônimo é obrigatório",
+      "pseudonymTooShort": "O pseudônimo deve ter pelo menos 2 caracteres",
+      "pseudonymTooLong": "O pseudônimo deve ter menos de {{max}} caracteres",
+      "pseudonymInvalidChars": "O pseudônimo pode conter apenas letras, números, sublinhados e hifens"
+    }
   }
 }

--- a/src/client/locales/ru.json
+++ b/src/client/locales/ru.json
@@ -3764,5 +3764,16 @@
   },
   "topbar": {
     "updateAvailable": "Обновить"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "Имя обязательно",
+      "firstNameTooLong": "Имя должно быть короче {{max}} символов",
+      "lastNameTooLong": "Фамилия должна быть короче {{max}} символов",
+      "pseudonymEmpty": "Псевдоним обязателен",
+      "pseudonymTooShort": "Псевдоним должен содержать не менее 2 символов",
+      "pseudonymTooLong": "Псевдоним должен быть короче {{max}} символов",
+      "pseudonymInvalidChars": "Псевдоним может содержать только буквы, цифры, символы подчёркивания и дефисы"
+    }
   }
 }

--- a/src/client/locales/zh-CN.json
+++ b/src/client/locales/zh-CN.json
@@ -3717,5 +3717,16 @@
   },
   "topbar": {
     "updateAvailable": "更新"
+  },
+  "validation": {
+    "profile": {
+      "firstNameEmpty": "请填写名字",
+      "firstNameTooLong": "名字必须少于 {{max}} 个字符",
+      "lastNameTooLong": "姓氏必须少于 {{max}} 个字符",
+      "pseudonymEmpty": "请填写昵称",
+      "pseudonymTooShort": "昵称至少需要 2 个字符",
+      "pseudonymTooLong": "昵称必须少于 {{max}} 个字符",
+      "pseudonymInvalidChars": "昵称只能包含字母、数字、下划线和连字符"
+    }
   }
 }

--- a/src/client/pages/invite/InvitePage.tsx
+++ b/src/client/pages/invite/InvitePage.tsx
@@ -12,29 +12,8 @@ import { AlertCircle, Camera, Loader2, ArrowLeft } from 'lucide-react'
 import { LanguageSelector, AgentLanguageSelector } from '@/client/components/common/LanguageSelector'
 import { getErrorMessage } from '@/client/lib/api'
 import { getUserInitials } from '@/client/lib/utils'
-
-const MAX_NAME_LENGTH = 100
-const MAX_PSEUDONYM_LENGTH = 30
-const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
-
-function validateProfileFields(input: {
-  firstName: string
-  lastName: string
-  pseudonym: string
-}): string | null {
-  const firstName = input.firstName.trim()
-  const lastName = input.lastName.trim()
-  const pseudonym = input.pseudonym.trim()
-
-  if (!firstName) return 'firstName cannot be empty'
-  if (firstName.length > MAX_NAME_LENGTH) return `firstName must be under ${MAX_NAME_LENGTH} characters`
-  if (lastName.length > MAX_NAME_LENGTH) return `lastName must be under ${MAX_NAME_LENGTH} characters`
-  if (!pseudonym || pseudonym.length < 2) return 'pseudonym must be at least 2 characters'
-  if (pseudonym.length > MAX_PSEUDONYM_LENGTH) return `pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`
-  if (!PSEUDONYM_REGEX.test(pseudonym)) return 'pseudonym can only contain letters, numbers, underscores, and hyphens'
-
-  return null
-}
+import { validateProfileFields } from '@/shared/profile-validation'
+import { translateProfileErrorCode } from '@/client/lib/profile-validation-i18n'
 
 export function InvitePage() {
   const { t, i18n } = useTranslation()
@@ -93,9 +72,12 @@ export function InvitePage() {
     e.preventDefault()
     setError('')
 
-    const profileError = validateProfileFields({ firstName, lastName, pseudonym })
-    if (profileError) {
-      setError(profileError)
+    const { issues } = validateProfileFields(
+      { firstName, lastName, pseudonym },
+      { require: ['firstName', 'pseudonym'] },
+    )
+    if (issues.length > 0) {
+      setError(translateProfileErrorCode(t, issues[0]!.code))
       return
     }
 

--- a/src/client/pages/invite/InvitePage.tsx
+++ b/src/client/pages/invite/InvitePage.tsx
@@ -13,6 +13,29 @@ import { LanguageSelector, AgentLanguageSelector } from '@/client/components/com
 import { getErrorMessage } from '@/client/lib/api'
 import { getUserInitials } from '@/client/lib/utils'
 
+const MAX_NAME_LENGTH = 100
+const MAX_PSEUDONYM_LENGTH = 30
+const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
+
+function validateProfileFields(input: {
+  firstName: string
+  lastName: string
+  pseudonym: string
+}): string | null {
+  const firstName = input.firstName.trim()
+  const lastName = input.lastName.trim()
+  const pseudonym = input.pseudonym.trim()
+
+  if (!firstName) return 'firstName cannot be empty'
+  if (firstName.length > MAX_NAME_LENGTH) return `firstName must be under ${MAX_NAME_LENGTH} characters`
+  if (lastName.length > MAX_NAME_LENGTH) return `lastName must be under ${MAX_NAME_LENGTH} characters`
+  if (!pseudonym || pseudonym.length < 2) return 'pseudonym must be at least 2 characters'
+  if (pseudonym.length > MAX_PSEUDONYM_LENGTH) return `pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`
+  if (!PSEUDONYM_REGEX.test(pseudonym)) return 'pseudonym can only contain letters, numbers, underscores, and hyphens'
+
+  return null
+}
+
 export function InvitePage() {
   const { t, i18n } = useTranslation()
   const { token } = useParams<{ token: string }>()
@@ -69,6 +92,12 @@ export function InvitePage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+
+    const profileError = validateProfileFields({ firstName, lastName, pseudonym })
+    if (profileError) {
+      setError(profileError)
+      return
+    }
 
     if (password !== passwordConfirm) {
       setError(t('invite.passwordMismatch'))

--- a/src/client/pages/onboarding/StepIdentity.tsx
+++ b/src/client/pages/onboarding/StepIdentity.tsx
@@ -10,38 +10,14 @@ import { AlertCircle, Camera, Loader2 } from 'lucide-react'
 import { useAuth } from '@/client/hooks/useAuth'
 import { api, getErrorMessage } from '@/client/lib/api'
 import { getUserInitials } from '@/client/lib/utils'
+import { validateProfileFields } from '@/shared/profile-validation'
+import { translateProfileErrorCode } from '@/client/lib/profile-validation-i18n'
 
 interface StepIdentityProps {
   onComplete: () => void
 }
 
 type FieldName = 'firstName' | 'lastName' | 'email' | 'pseudonym' | 'password' | 'passwordConfirm'
-
-const MAX_NAME_LENGTH = 100
-const MAX_PSEUDONYM_LENGTH = 30
-const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
-
-function validateProfileFields(input: {
-  firstName: string
-  lastName: string
-  pseudonym: string
-}): Partial<Record<FieldName, string>> {
-  const fields: Partial<Record<FieldName, string>> = {}
-  const firstName = input.firstName.trim()
-  const lastName = input.lastName.trim()
-  const pseudonym = input.pseudonym.trim()
-
-  if (!firstName) fields.firstName = 'firstName cannot be empty'
-  else if (firstName.length > MAX_NAME_LENGTH) fields.firstName = `firstName must be under ${MAX_NAME_LENGTH} characters`
-
-  if (lastName.length > MAX_NAME_LENGTH) fields.lastName = `lastName must be under ${MAX_NAME_LENGTH} characters`
-
-  if (!pseudonym || pseudonym.length < 2) fields.pseudonym = 'pseudonym must be at least 2 characters'
-  else if (pseudonym.length > MAX_PSEUDONYM_LENGTH) fields.pseudonym = `pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`
-  else if (!PSEUDONYM_REGEX.test(pseudonym)) fields.pseudonym = 'pseudonym can only contain letters, numbers, underscores, and hyphens'
-
-  return fields
-}
 
 /**
  * Translate the Better Auth body field name into the local form
@@ -198,8 +174,15 @@ export function StepIdentity({ onComplete }: StepIdentityProps) {
     setError('')
     setFieldErrors({})
 
-    const profileErrors = validateProfileFields({ firstName, lastName, pseudonym })
-    if (Object.keys(profileErrors).length > 0) {
+    const { issues } = validateProfileFields(
+      { firstName, lastName, pseudonym },
+      { require: ['firstName', 'pseudonym'] },
+    )
+    if (issues.length > 0) {
+      const profileErrors: Partial<Record<FieldName, string>> = {}
+      for (const issue of issues) {
+        if (!profileErrors[issue.field]) profileErrors[issue.field] = translateProfileErrorCode(t, issue.code)
+      }
       setFieldErrors(profileErrors)
       return
     }

--- a/src/client/pages/onboarding/StepIdentity.tsx
+++ b/src/client/pages/onboarding/StepIdentity.tsx
@@ -17,6 +17,32 @@ interface StepIdentityProps {
 
 type FieldName = 'firstName' | 'lastName' | 'email' | 'pseudonym' | 'password' | 'passwordConfirm'
 
+const MAX_NAME_LENGTH = 100
+const MAX_PSEUDONYM_LENGTH = 30
+const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
+
+function validateProfileFields(input: {
+  firstName: string
+  lastName: string
+  pseudonym: string
+}): Partial<Record<FieldName, string>> {
+  const fields: Partial<Record<FieldName, string>> = {}
+  const firstName = input.firstName.trim()
+  const lastName = input.lastName.trim()
+  const pseudonym = input.pseudonym.trim()
+
+  if (!firstName) fields.firstName = 'firstName cannot be empty'
+  else if (firstName.length > MAX_NAME_LENGTH) fields.firstName = `firstName must be under ${MAX_NAME_LENGTH} characters`
+
+  if (lastName.length > MAX_NAME_LENGTH) fields.lastName = `lastName must be under ${MAX_NAME_LENGTH} characters`
+
+  if (!pseudonym || pseudonym.length < 2) fields.pseudonym = 'pseudonym must be at least 2 characters'
+  else if (pseudonym.length > MAX_PSEUDONYM_LENGTH) fields.pseudonym = `pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`
+  else if (!PSEUDONYM_REGEX.test(pseudonym)) fields.pseudonym = 'pseudonym can only contain letters, numbers, underscores, and hyphens'
+
+  return fields
+}
+
 /**
  * Translate the Better Auth body field name into the local form
  * field name. Better Auth's sign-up body uses { name, email, password };
@@ -111,6 +137,21 @@ function extractFieldErrors(err: unknown): {
   return { fields, fallback }
 }
 
+function isExistingUserError(err: unknown): boolean {
+  const message = getErrorMessage(err).toLowerCase()
+  const o = err as { code?: unknown; error?: { code?: unknown } }
+  const code = typeof o?.code === 'string'
+    ? o.code
+    : typeof o?.error?.code === 'string'
+      ? o.error.code
+      : ''
+  return (
+    code === 'USER_ALREADY_EXISTS' ||
+    message.includes('already') ||
+    message.includes('exists')
+  )
+}
+
 export function StepIdentity({ onComplete }: StepIdentityProps) {
   const { t, i18n } = useTranslation()
   const { register, login } = useAuth()
@@ -157,6 +198,12 @@ export function StepIdentity({ onComplete }: StepIdentityProps) {
     setError('')
     setFieldErrors({})
 
+    const profileErrors = validateProfileFields({ firstName, lastName, pseudonym })
+    if (Object.keys(profileErrors).length > 0) {
+      setFieldErrors(profileErrors)
+      return
+    }
+
     if (password !== passwordConfirm) {
       setFieldErrors({ passwordConfirm: t('onboarding.identity.passwordMismatch') })
       return
@@ -176,8 +223,7 @@ export function StepIdentity({ onComplete }: StepIdentityProps) {
         // If registration fails because email already exists, try logging in instead.
         // This handles the case where registration succeeded but profile creation
         // failed on a previous attempt, leaving the user stuck.
-        const regMsg = getErrorMessage(regErr) || ''
-        if (regMsg.toLowerCase().includes('already') || regMsg.toLowerCase().includes('exists')) {
+        if (isExistingUserError(regErr)) {
           await login(email, password)
         } else {
           throw regErr

--- a/src/server/lib/profile-validation-messages.ts
+++ b/src/server/lib/profile-validation-messages.ts
@@ -1,0 +1,28 @@
+/**
+ * Server-side English messages for profile validation issue codes.
+ *
+ * The API has no locale context, so routes return English (matching the
+ * pre-existing `; `-joined VALIDATION_ERROR contract). Clients localize the
+ * codes themselves; this map is only for the server's error payloads.
+ */
+import {
+  MAX_NAME_LENGTH,
+  MAX_PSEUDONYM_LENGTH,
+  type ProfileErrorCode,
+  type ProfileIssue,
+} from '@/shared/profile-validation'
+
+const MESSAGES: Record<ProfileErrorCode, string> = {
+  first_name_empty: 'firstName cannot be empty',
+  first_name_too_long: `firstName must be under ${MAX_NAME_LENGTH} characters`,
+  last_name_too_long: `lastName must be under ${MAX_NAME_LENGTH} characters`,
+  // Empty and too-short both surface as the same message the route used before.
+  pseudonym_empty: 'pseudonym must be at least 2 characters',
+  pseudonym_too_short: 'pseudonym must be at least 2 characters',
+  pseudonym_too_long: `pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`,
+  pseudonym_invalid_chars: 'pseudonym can only contain letters, numbers, underscores, and hyphens',
+}
+
+export function profileIssueMessage(issue: ProfileIssue): string {
+  return MESSAGES[issue.code]
+}

--- a/src/server/routes/me.ts
+++ b/src/server/routes/me.ts
@@ -4,6 +4,8 @@ import { db } from '@/server/db/index'
 import { userProfiles, user } from '@/server/db/schema'
 import { getUnreadCountsForUser } from '@/server/services/agent-read-state'
 import { THEME_MODES, CONTRAST_MODES, PALETTE_IDS, SUPPORTED_LANGUAGES, AGENT_LANGUAGE_CODES } from '@/shared/constants'
+import { validateProfileFields } from '@/shared/profile-validation'
+import { profileIssueMessage } from '@/server/lib/profile-validation-messages'
 import type { AppVariables } from '@/server/app'
 import { createLogger } from '@/server/logger'
 import { config } from '@/server/config'
@@ -61,28 +63,16 @@ meRoutes.patch('/', async (c) => {
   const body = await c.req.json()
 
   // Input validation
-  const MAX_NAME_LENGTH = 100
-  const MAX_PSEUDONYM_LENGTH = 30
-  const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
-
   const errors: string[] = []
 
-  if (body.firstName !== undefined) {
-    if (typeof body.firstName !== 'string') errors.push('firstName must be a string')
-    else body.firstName = body.firstName.trim()
-    if (typeof body.firstName === 'string' && body.firstName.length > MAX_NAME_LENGTH) errors.push(`firstName must be under ${MAX_NAME_LENGTH} characters`)
-  }
-  if (body.lastName !== undefined) {
-    if (typeof body.lastName !== 'string') errors.push('lastName must be a string')
-    else body.lastName = body.lastName.trim()
-    if (typeof body.lastName === 'string' && body.lastName.length > MAX_NAME_LENGTH) errors.push(`lastName must be under ${MAX_NAME_LENGTH} characters`)
-  }
-  if (body.pseudonym !== undefined) {
-    if (typeof body.pseudonym !== 'string') errors.push('pseudonym must be a string')
-    else body.pseudonym = body.pseudonym.trim()
-    if (typeof body.pseudonym === 'string' && body.pseudonym.length > MAX_PSEUDONYM_LENGTH) errors.push(`pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`)
-    if (typeof body.pseudonym === 'string' && body.pseudonym.length > 0 && !PSEUDONYM_REGEX.test(body.pseudonym)) errors.push('pseudonym can only contain letters, numbers, underscores, and hyphens')
-  }
+  // Name/pseudonym trio via the shared validator. PATCH is partial, so nothing
+  // is required; format rules (incl. pseudonym min length) apply to any present,
+  // non-empty value. Trimmed values are written back for the present fields.
+  const { issues: profileIssues, values: profileValues } = validateProfileFields(body, { require: [] })
+  for (const issue of profileIssues) errors.push(profileIssueMessage(issue))
+  if (body.firstName !== undefined) body.firstName = profileValues.firstName
+  if (body.lastName !== undefined) body.lastName = profileValues.lastName
+  if (body.pseudonym !== undefined) body.pseudonym = profileValues.pseudonym
   if (body.language !== undefined) {
     if (!(SUPPORTED_LANGUAGES as readonly string[]).includes(body.language)) errors.push(`language must be one of: ${SUPPORTED_LANGUAGES.join(', ')}`)
   }

--- a/src/server/routes/onboarding.test.ts
+++ b/src/server/routes/onboarding.test.ts
@@ -361,6 +361,59 @@ describe('onboarding routes', () => {
       expect(body.error.code).toBe('VALIDATION_ERROR')
     })
 
+    it('returns 400 for a one-character pseudonym (the onboarding bug)', async () => {
+      mockGetSession = mock(() => Promise.resolve(fakeSession))
+      mockDbSelect = mock(() => makeChain(null))
+
+      const res = await app.request(
+        jsonRequest('/api/onboarding/profile', {
+          firstName: 'John',
+          lastName: 'Doe',
+          pseudonym: 'a',
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+      // No auth user side effects: profile insert must not run on validation failure.
+      expect(mockDbInsert).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for a pseudonym with invalid characters', async () => {
+      mockGetSession = mock(() => Promise.resolve(fakeSession))
+      mockDbSelect = mock(() => makeChain(null))
+
+      const res = await app.request(
+        jsonRequest('/api/onboarding/profile', {
+          firstName: 'John',
+          lastName: 'Doe',
+          pseudonym: 'john doe',
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
+    it('returns 400 for an over-long pseudonym', async () => {
+      mockGetSession = mock(() => Promise.resolve(fakeSession))
+      mockDbSelect = mock(() => makeChain(null))
+
+      const res = await app.request(
+        jsonRequest('/api/onboarding/profile', {
+          firstName: 'John',
+          lastName: 'Doe',
+          pseudonym: 'a'.repeat(31),
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error.code).toBe('VALIDATION_ERROR')
+    })
+
     it('creates admin profile for first user (no admin exists)', async () => {
       mockGetSession = mock(() => Promise.resolve(fakeSession))
 

--- a/src/server/routes/onboarding.ts
+++ b/src/server/routes/onboarding.ts
@@ -7,6 +7,8 @@ import { createLogger } from '@/server/logger'
 import { createContact, findContactByLinkedUserId } from '@/server/services/contacts'
 import { validateInvitation, markInvitationUsed } from '@/server/services/invitations'
 import { SUPPORTED_LANGUAGES, AGENT_LANGUAGE_CODES } from '@/shared/constants'
+import { validateProfileFields } from '@/shared/profile-validation'
+import { profileIssueMessage } from '@/server/lib/profile-validation-messages'
 
 const log = createLogger('routes:onboarding')
 const onboardingRoutes = new Hono()
@@ -90,30 +92,17 @@ onboardingRoutes.post('/profile', async (c) => {
     invitationToken?: string
   }
 
-  if (!firstName || !pseudonym) {
-    return c.json(
-      { error: { code: 'VALIDATION_ERROR', message: 'firstName and pseudonym are required' } },
-      400,
-    )
-  }
+  // Validate and sanitize the name/pseudonym trio via the shared validator
+  // (signup requires firstName + pseudonym). Language checks stay here since
+  // they depend on server-side constants and aren't part of the shared trio.
+  const { issues, values } = validateProfileFields(
+    { firstName, lastName, pseudonym },
+    { require: ['firstName', 'pseudonym'] },
+  )
+  const { firstName: trimmedFirstName, lastName: trimmedLastName, pseudonym: trimmedPseudonym } = values
 
-  // Validate and sanitize fields (same rules as PATCH /api/me)
-  const MAX_NAME_LENGTH = 100
-  const MAX_PSEUDONYM_LENGTH = 30
-  const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
+  const validationErrors: string[] = issues.map(profileIssueMessage)
 
-  const trimmedFirstName = String(firstName).trim()
-  const trimmedLastName = String(lastName ?? '').trim()
-  const trimmedPseudonym = String(pseudonym).trim()
-
-  const validationErrors: string[] = []
-
-  if (!trimmedFirstName) validationErrors.push('firstName cannot be empty')
-  if (trimmedFirstName.length > MAX_NAME_LENGTH) validationErrors.push(`firstName must be under ${MAX_NAME_LENGTH} characters`)
-  if (trimmedLastName.length > MAX_NAME_LENGTH) validationErrors.push(`lastName must be under ${MAX_NAME_LENGTH} characters`)
-  if (!trimmedPseudonym || trimmedPseudonym.length < 2) validationErrors.push('pseudonym must be at least 2 characters')
-  if (trimmedPseudonym.length > MAX_PSEUDONYM_LENGTH) validationErrors.push(`pseudonym must be under ${MAX_PSEUDONYM_LENGTH} characters`)
-  if (trimmedPseudonym.length > 0 && !PSEUDONYM_REGEX.test(trimmedPseudonym)) validationErrors.push('pseudonym can only contain letters, numbers, underscores, and hyphens')
   if (language && !SUPPORTED_LANGUAGES.includes(language as typeof SUPPORTED_LANGUAGES[number])) validationErrors.push(`language must be one of: ${SUPPORTED_LANGUAGES.join(', ')}`)
   if (agentLanguage != null && !AGENT_LANGUAGE_CODES.includes(agentLanguage)) validationErrors.push('agentLanguage must be a supported agent language code')
 

--- a/src/shared/profile-validation.test.ts
+++ b/src/shared/profile-validation.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'bun:test'
+import { validateProfileFields, type ProfileErrorCode } from '@/shared/profile-validation'
+
+const SIGNUP = { require: ['firstName', 'pseudonym'] as const }
+const PATCH = { require: [] as const }
+
+function codes(input: Parameters<typeof validateProfileFields>[0], opts: Parameters<typeof validateProfileFields>[1]): ProfileErrorCode[] {
+  return validateProfileFields(input, opts).issues.map((i) => i.code)
+}
+
+describe('validateProfileFields', () => {
+  it('accepts a valid signup payload', () => {
+    const { issues, values } = validateProfileFields(
+      { firstName: 'John', lastName: 'Doe', pseudonym: 'johnd' },
+      SIGNUP,
+    )
+    expect(issues).toEqual([])
+    expect(values).toEqual({ firstName: 'John', lastName: 'Doe', pseudonym: 'johnd' })
+  })
+
+  it('trims values and returns the cleaned strings', () => {
+    const { values } = validateProfileFields(
+      { firstName: '  John  ', lastName: '  Doe ', pseudonym: '  johnd ' },
+      SIGNUP,
+    )
+    expect(values).toEqual({ firstName: 'John', lastName: 'Doe', pseudonym: 'johnd' })
+  })
+
+  it('coerces non-string input before validating', () => {
+    const { values } = validateProfileFields({ firstName: 123, pseudonym: 'abc' }, SIGNUP)
+    expect(values.firstName).toBe('123')
+  })
+
+  // ─── signup (require firstName + pseudonym) ───────────────────────────────
+
+  it('flags an empty first name on signup', () => {
+    expect(codes({ firstName: '   ', pseudonym: 'johnd' }, SIGNUP)).toContain('first_name_empty')
+  })
+
+  it('flags a missing first name on signup', () => {
+    expect(codes({ pseudonym: 'johnd' }, SIGNUP)).toContain('first_name_empty')
+  })
+
+  it('flags an over-long first name', () => {
+    expect(codes({ firstName: 'a'.repeat(101), pseudonym: 'johnd' }, SIGNUP)).toContain('first_name_too_long')
+  })
+
+  it('flags an over-long last name', () => {
+    expect(codes({ firstName: 'John', lastName: 'a'.repeat(101), pseudonym: 'johnd' }, SIGNUP)).toContain('last_name_too_long')
+  })
+
+  it('flags an empty pseudonym on signup', () => {
+    expect(codes({ firstName: 'John', pseudonym: '' }, SIGNUP)).toContain('pseudonym_empty')
+  })
+
+  it('flags a one-character pseudonym as too short (the bug case)', () => {
+    expect(codes({ firstName: 'John', pseudonym: 'a' }, SIGNUP)).toContain('pseudonym_too_short')
+  })
+
+  it('flags an over-long pseudonym', () => {
+    expect(codes({ firstName: 'John', pseudonym: 'a'.repeat(31) }, SIGNUP)).toContain('pseudonym_too_long')
+  })
+
+  it('flags invalid pseudonym characters', () => {
+    expect(codes({ firstName: 'John', pseudonym: 'john doe' }, SIGNUP)).toContain('pseudonym_invalid_chars')
+  })
+
+  it('accepts hyphens and underscores in the pseudonym', () => {
+    expect(codes({ firstName: 'John', pseudonym: 'john_d-2' }, SIGNUP)).toEqual([])
+  })
+
+  // ─── PATCH (require nothing) ──────────────────────────────────────────────
+
+  it('produces no issues for an empty partial PATCH', () => {
+    expect(codes({}, PATCH)).toEqual([])
+  })
+
+  it('does not require firstName/pseudonym on PATCH', () => {
+    expect(codes({ firstName: '', pseudonym: '' }, PATCH)).toEqual([])
+  })
+
+  it('still rejects a one-character pseudonym on PATCH (deliberate consistency change)', () => {
+    expect(codes({ pseudonym: 'a' }, PATCH)).toContain('pseudonym_too_short')
+  })
+
+  it('still enforces format rules on present PATCH fields', () => {
+    expect(codes({ pseudonym: 'bad name!' }, PATCH)).toContain('pseudonym_invalid_chars')
+    expect(codes({ firstName: 'a'.repeat(101) }, PATCH)).toContain('first_name_too_long')
+  })
+})

--- a/src/shared/profile-validation.ts
+++ b/src/shared/profile-validation.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared profile-field validation for the name/pseudonym trio.
+ *
+ * Single source of truth consumed by:
+ *  - the onboarding signup form (StepIdentity) and invite signup (InvitePage)
+ *  - the server onboarding route (POST /api/onboarding/profile)
+ *  - the server profile route (PATCH /api/me)
+ *
+ * This module is pure: it returns structured issue codes (never English or
+ * localized strings) plus the trimmed values, so each caller can render the
+ * codes the way it needs (server -> English message map, client -> i18n).
+ * It must NOT import i18n, the DB, or anything client/server specific.
+ *
+ * Presence is a per-caller policy via `opts.require`: signup requires
+ * firstName + pseudonym, while PATCH /api/me is partial and requires nothing.
+ * Format rules (length, regex, pseudonym min length) apply to any present,
+ * non-empty value regardless of `require`.
+ */
+
+export const MAX_NAME_LENGTH = 100
+export const MAX_PSEUDONYM_LENGTH = 30
+export const MIN_PSEUDONYM_LENGTH = 2
+export const PSEUDONYM_REGEX = /^[a-zA-Z0-9_-]+$/
+
+export type ProfileField = 'firstName' | 'lastName' | 'pseudonym'
+
+export type ProfileErrorCode =
+  | 'first_name_empty'
+  | 'first_name_too_long'
+  | 'last_name_too_long'
+  | 'pseudonym_empty'
+  | 'pseudonym_too_short'
+  | 'pseudonym_too_long'
+  | 'pseudonym_invalid_chars'
+
+export type ProfileIssue = { field: ProfileField; code: ProfileErrorCode }
+
+export interface ProfileFieldsInput {
+  firstName?: unknown
+  lastName?: unknown
+  pseudonym?: unknown
+}
+
+export interface ValidateProfileOptions {
+  /** Fields that must be present and non-empty (signup requires firstName + pseudonym). */
+  require: readonly ProfileField[]
+}
+
+export interface ProfileValidationResult {
+  issues: ProfileIssue[]
+  values: { firstName: string; lastName: string; pseudonym: string }
+}
+
+/** Coerce an unknown input to a trimmed string (undefined/null -> ''). */
+function toTrimmed(value: unknown): string {
+  if (value === undefined || value === null) return ''
+  return String(value).trim()
+}
+
+export function validateProfileFields(
+  input: ProfileFieldsInput,
+  opts: ValidateProfileOptions,
+): ProfileValidationResult {
+  const firstName = toTrimmed(input.firstName)
+  const lastName = toTrimmed(input.lastName)
+  const pseudonym = toTrimmed(input.pseudonym)
+
+  const issues: ProfileIssue[] = []
+  const requires = (field: ProfileField) => opts.require.includes(field)
+
+  // firstName
+  if (!firstName) {
+    if (requires('firstName')) issues.push({ field: 'firstName', code: 'first_name_empty' })
+  } else if (firstName.length > MAX_NAME_LENGTH) {
+    issues.push({ field: 'firstName', code: 'first_name_too_long' })
+  }
+
+  // lastName (never required, only length-bounded)
+  if (lastName.length > MAX_NAME_LENGTH) {
+    issues.push({ field: 'lastName', code: 'last_name_too_long' })
+  }
+
+  // pseudonym
+  if (!pseudonym) {
+    if (requires('pseudonym')) issues.push({ field: 'pseudonym', code: 'pseudonym_empty' })
+  } else {
+    if (pseudonym.length < MIN_PSEUDONYM_LENGTH) issues.push({ field: 'pseudonym', code: 'pseudonym_too_short' })
+    if (pseudonym.length > MAX_PSEUDONYM_LENGTH) issues.push({ field: 'pseudonym', code: 'pseudonym_too_long' })
+    if (!PSEUDONYM_REGEX.test(pseudonym)) issues.push({ field: 'pseudonym', code: 'pseudonym_invalid_chars' })
+  }
+
+  return { issues, values: { firstName, lastName, pseudonym } }
+}


### PR DESCRIPTION
## Description

First-run signup created the Better Auth user before validating the profile, so a
bad pseudonym (one char was the repro) left you logged in with no profile:
"Account setup incomplete. Please complete onboarding," and retrying could fail
because the auth user already existed. Invite signup had the same ordering.

Fix is ordering: both signup forms (StepIdentity, InvitePage) validate
firstName/lastName/pseudonym locally and bail before calling Better Auth, so a bad
pseudonym never creates an auth user. The existing "user already exists" recovery
in StepIdentity stays, just gated on the real `USER_ALREADY_EXISTS` code now
instead of sniffing the message, so it doesn't swallow unrelated errors.

Those rules were copy-pasted in 4 places (both forms, the onboarding route, PATCH
/api/me), so they're now one shared validator in `src/shared/profile-validation.ts`
that returns issue codes + trimmed values. Presence is per-caller: signup requires
firstName + pseudonym, PATCH /api/me stays partial. Server maps codes to its
existing English `VALIDATION_ERROR` strings (API response unchanged); the clients
localize via i18n, with new `validation.profile.*` keys in all 10 locales (was
hardcoded English before).

One intentional behavior change worth a look: a one-char pseudonym is now rejected
on PATCH /api/me too (it was allowed there before, even though onboarding wasn't).
me.ts also coerces non-string name fields instead of erroring on type, matching how
the onboarding route always behaved.

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactor / cleanup

## Related Issues

N/A, no issue was opened for this.

## How to Test

Repro on a fresh instance: start onboarding, enter a one-char pseudonym, submit.
Before, the auth user gets created, then profile creation 400s and you're stuck
on "Account setup incomplete." After, you get an inline validation error and no
account is created. Same deal on the invite page.

- [x] Unit tests (`bun test`): new shared validator test + onboarding route cases; targeted suites green (36/36). Full `bun test` has 40 failures, but they're identical on `main` (Windows-only unix-path/symlink/shell tests), not from this change. Green in CI on Linux.
- [ ] E2E tests (`bun run e2e`)
- [ ] Manual testing
- [ ] N/A (docs only)

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I've tested this locally
- [x] The build passes (`bun run build`)
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] New code follows existing patterns and conventions
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated documentation if needed: might be worth a one-liner in `api.md` for the stricter PATCH /api/me pseudonym rule, happy to add if you want it
- [x] User-facing strings use `useTranslation()` with keys in both `en.json` and `fr.json` (added across all 10 locales)
- [x] No hardcoded colors (no UI color changes here)
- [x] Shared types in `src/shared/types.ts`, shared constants in `src/shared/constants.ts`: validation constants are colocated in the new `src/shared/profile-validation.ts` module, same pattern as other `src/shared/*` modules
- [x] Breaking changes are noted above (the PATCH /api/me pseudonym tightening)
