### PR TITLE
fix(runtime): harden Codex, restart flow, tool previews, and restart gating

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,8 +15,12 @@ if [ $? -ne 0 ]; then
 fi
 
 # 2. Unit tests
+# Use `bun run test` (the npm script), not a bare `bun test`: the script passes
+# an explicit, sorted file list. Bare discovery runs test files in an order that
+# leaks global state between them (mock.module is process-global), producing
+# spurious failures. The sorted invocation is the project's source of truth.
 echo "🧪 Running unit tests..."
-bun test 2>&1
+bun run test 2>&1
 if [ $? -ne 0 ]; then
   echo "❌ Unit tests failed. Fix failing tests before committing."
   exit 1

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "db:snapshot:restore": "bun scripts/db-snapshot.ts restore",
     "test": "bun test $(find ./src ./packages/sdk/src ./packages/create-hivekeep-plugin ./plugins -name '*.test.ts' | sort)",
     "test:e2e": "npx playwright test",
-    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
+    "typecheck": "NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" tsc --noEmit",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "db:snapshot:restore": "bun scripts/db-snapshot.ts restore",
     "test": "bun test $(find ./src ./packages/sdk/src ./packages/create-hivekeep-plugin ./plugins -name '*.test.ts' | sort)",
     "test:e2e": "npx playwright test",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/src/client/components/chat/InlineToolCall.test.ts
+++ b/src/client/components/chat/InlineToolCall.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { normalizeToolCallArgs } from './InlineToolCall'
+
+describe('normalizeToolCallArgs', () => {
+  test('normalizes missing pending tool-call args to an empty object', () => {
+    expect(normalizeToolCallArgs(undefined)).toEqual({})
+    expect(normalizeToolCallArgs(null)).toEqual({})
+  })
+
+  test('preserves provided args objects', () => {
+    const args = { value: 42 }
+    expect(normalizeToolCallArgs(args)).toBe(args)
+  })
+})

--- a/src/client/components/chat/InlineToolCall.tsx
+++ b/src/client/components/chat/InlineToolCall.tsx
@@ -54,7 +54,8 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
     ? toolCall.name.slice('custom_'.length)
     : null
   const previewFn = getPreviewRenderer(toolCall.name)
-  const preview = previewFn?.({ toolName: toolCall.name, args: toolCall.args as Record<string, unknown>, status: toolCall.status })
+  const args = (toolCall.args ?? {}) as Record<string, unknown>
+  const preview = previewFn?.({ toolName: toolCall.name, args, status: toolCall.status })
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -83,7 +84,7 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
             {CustomRenderer ? (
               <CustomRenderer
                 toolName={toolCall.name}
-                args={toolCall.args as Record<string, unknown>}
+                args={args}
                 result={toolCall.result}
                 status={toolCall.status}
               />
@@ -96,7 +97,7 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
             ) : (
               <>
                 <JsonViewer
-                  data={toolCall.args}
+                  data={args}
                   label={t('tools.viewer.input')}
                   maxHeight="max-h-40"
                 />

--- a/src/client/components/chat/InlineToolCall.tsx
+++ b/src/client/components/chat/InlineToolCall.tsx
@@ -32,6 +32,10 @@ interface InlineToolCallProps {
   toolCall: ToolCallViewItem
 }
 
+export function normalizeToolCallArgs(args: unknown): Record<string, unknown> {
+  return (args ?? {}) as Record<string, unknown>
+}
+
 /** Compact collapsible inline tool call shown within the Agent's message flow. */
 export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineToolCallProps) {
   const { t } = useTranslation()
@@ -54,7 +58,7 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
     ? toolCall.name.slice('custom_'.length)
     : null
   const previewFn = getPreviewRenderer(toolCall.name)
-  const args = (toolCall.args ?? {}) as Record<string, unknown>
+  const args = normalizeToolCallArgs(toolCall.args)
   const preview = previewFn?.({ toolName: toolCall.name, args, status: toolCall.status })
 
   return (
@@ -92,7 +96,7 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
               <CustomToolRenderer
                 slug={customSlug}
                 result={toolCall.result}
-                args={toolCall.args}
+                args={args}
               />
             ) : (
               <>

--- a/src/client/components/chat/ToolCallItem.tsx
+++ b/src/client/components/chat/ToolCallItem.tsx
@@ -57,7 +57,8 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
   const customSlug = isCustomTool ? toolCall.name.slice('custom_'.length) : null
   const humanName = customName ?? t(`tools.names.${toolCall.name}`, { defaultValue: toolCall.name })
   const previewFn = getPreviewRenderer(toolCall.name)
-  const preview = previewFn?.({ toolName: toolCall.name, args: toolCall.args as Record<string, unknown>, status: toolCall.status })
+  const args = (toolCall.args ?? {}) as Record<string, unknown>
+  const preview = previewFn?.({ toolName: toolCall.name, args, status: toolCall.status })
   const timeStr = new Date(toolCall.timestamp).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
@@ -92,7 +93,7 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
             {CustomRenderer ? (
               <CustomRenderer
                 toolName={toolCall.name}
-                args={toolCall.args as Record<string, unknown>}
+                args={args}
                 result={toolCall.result}
                 status={toolCall.status}
               />
@@ -105,7 +106,7 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
             ) : (
               <>
                 <JsonViewer
-                  data={toolCall.args}
+                  data={args}
                   label={t('tools.viewer.input')}
                   maxHeight="max-h-40"
                 />

--- a/src/client/components/chat/renderers/FileEditRenderer.tsx
+++ b/src/client/components/chat/renderers/FileEditRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, FilePen, FileWarning } from 'lucide-react'
+import { ChevronDown, ChevronRight, FilePen, FileWarning, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -19,7 +19,9 @@ export function FileEditRenderer({ args, result, status }: ToolResultRendererPro
   const editLine = typeof res?.editLine === 'number' ? res.editLine : null
   const error = typeof res?.error === 'string' ? res.error : null
 
-  if (!success) {
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -29,6 +31,21 @@ export function FileEditRenderer({ args, result, status }: ToolResultRendererPro
             <span className="ml-auto shrink-0 text-[10px] text-red-400">{t('tools.renderers.failed')}</span>
           </div>
           <div className="px-3 py-2 text-red-300 break-words">{error ?? t('tools.renderers.editFailed')}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{filePath ?? t('tools.renderers.file')}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.editingFile', { defaultValue: 'Preparing edit preview…' })}</div>
         </div>
       </div>
     )

--- a/src/client/components/chat/renderers/FileEditRenderer.tsx
+++ b/src/client/components/chat/renderers/FileEditRenderer.tsx
@@ -10,11 +10,11 @@ export function FileEditRenderer({ args, result, status }: ToolResultRendererPro
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const applied = res?.applied === true
-  const oldText = typeof res?.oldText === 'string' ? res.oldText : typeof args.oldText === 'string' ? args.oldText : null
-  const newText = typeof res?.newText === 'string' ? res.newText : typeof args.newText === 'string' ? args.newText : null
+  const oldText = typeof res?.oldText === 'string' ? res.oldText : typeof args?.oldText === 'string' ? args.oldText : null
+  const newText = typeof res?.newText === 'string' ? res.newText : typeof args?.newText === 'string' ? args.newText : null
   const language = typeof res?.language === 'string' ? res.language : null
   const editLine = typeof res?.editLine === 'number' ? res.editLine : null
   const error = typeof res?.error === 'string' ? res.error : null

--- a/src/client/components/chat/renderers/FileReadRenderer.tsx
+++ b/src/client/components/chat/renderers/FileReadRenderer.tsx
@@ -10,7 +10,7 @@ export function FileReadRenderer({ args, result, status }: ToolResultRendererPro
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof args.path === 'string' ? args.path : null
+  const filePath = typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const content = typeof res?.content === 'string' ? res.content : null
   const language = typeof res?.language === 'string' ? res.language : null

--- a/src/client/components/chat/renderers/FileWriteRenderer.tsx
+++ b/src/client/components/chat/renderers/FileWriteRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, FilePlus, FilePen } from 'lucide-react'
+import { ChevronDown, ChevronRight, FilePlus, FilePen, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -57,7 +57,9 @@ export function FileWriteRenderer({ args, result, status }: ToolResultRendererPr
   const content = typeof args?.content === 'string' ? args.content : null
   const error = typeof res?.error === 'string' ? res.error : null
 
-  if (!success) {
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -67,6 +69,21 @@ export function FileWriteRenderer({ args, result, status }: ToolResultRendererPr
             <span className="ml-auto shrink-0 text-[10px] text-red-400">{t('tools.renderers.error')}</span>
           </div>
           <div className="px-3 py-2 text-red-300 break-words">{error ?? t('tools.renderers.writeFailed')}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{filePath ?? t('tools.renderers.file')}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.writingFile', { defaultValue: 'Preparing write preview…' })}</div>
         </div>
       </div>
     )

--- a/src/client/components/chat/renderers/FileWriteRenderer.tsx
+++ b/src/client/components/chat/renderers/FileWriteRenderer.tsx
@@ -47,14 +47,14 @@ export function FileWriteRenderer({ args, result, status }: ToolResultRendererPr
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const created = res?.created === true
   const bytesWritten = typeof res?.bytesWritten === 'number' ? res.bytesWritten : null
   const linesWritten = typeof res?.linesWritten === 'number' ? res.linesWritten : null
   const language = typeof res?.language === 'string' ? res.language : null
   const previousContent = typeof res?.previousContent === 'string' ? res.previousContent : null
-  const content = typeof args.content === 'string' ? args.content : null
+  const content = typeof args?.content === 'string' ? args.content : null
   const error = typeof res?.error === 'string' ? res.error : null
 
   if (!success) {

--- a/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
+++ b/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
@@ -75,7 +75,7 @@ export function ListDirectoryRenderer({ args, result, status }: ToolResultRender
 
   const res = result as Record<string, unknown> | null | undefined
   const success = res?.success === true
-  const dirPath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : '.'
+  const dirPath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : '.'
   const entries = Array.isArray(res?.entries) ? (res.entries as DirEntry[]) : null
   const error = typeof res?.error === 'string' ? res.error : null
 

--- a/src/client/components/chat/renderers/MultiEditRenderer.tsx
+++ b/src/client/components/chat/renderers/MultiEditRenderer.tsx
@@ -21,14 +21,14 @@ export function MultiEditRenderer({ args, result, status }: ToolResultRendererPr
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const language = typeof res?.language === 'string' ? res.language : null
   const editsApplied = typeof res?.editsApplied === 'number' ? res.editsApplied : null
   const error = typeof res?.error === 'string' ? res.error : null
   const failedEditIndex = typeof res?.failedEditIndex === 'number' ? res.failedEditIndex : null
 
-  const edits = Array.isArray(args.edits) ? (args.edits as EditPair[]) : null
+  const edits = Array.isArray(args?.edits) ? (args.edits as EditPair[]) : null
 
   if (!success) {
     return (

--- a/src/client/hooks/useAgents.ts
+++ b/src/client/hooks/useAgents.ts
@@ -94,19 +94,27 @@ export function useAgents() {
     try {
       const data = await api.get<{ agents: (AgentSummary & { isProcessing?: boolean; queueSize?: number; processingStartedAt?: number })[] }>('/agents')
       setAgents(data.agents)
-      // Hydrate queue state from initial fetch so we don't miss processing state
+      // Hydrate queue state from initial fetch/resync. Write an entry for every
+      // Agent, including idle ones, so a missed final queue:update cannot leave
+      // a stale isProcessing=true indicator stuck until a full page reload.
       setAgentQueueState((prev) => {
         const next = new Map(prev)
+        const seen = new Set<string>()
         for (const agent of data.agents) {
-          if (agent.isProcessing || (agent.queueSize && agent.queueSize > 0)) {
-            const existing = next.get(agent.id)
-            next.set(agent.id, {
-              ...existing,
-              isProcessing: agent.isProcessing ?? false,
-              queueSize: agent.queueSize ?? 0,
-              processingStartedAt: agent.processingStartedAt ?? existing?.processingStartedAt,
-            })
-          }
+          seen.add(agent.id)
+          const existing = next.get(agent.id)
+          const isProcessing = agent.isProcessing ?? false
+          next.set(agent.id, {
+            ...existing,
+            isProcessing,
+            queueSize: agent.queueSize ?? 0,
+            processingStartedAt: isProcessing
+              ? agent.processingStartedAt ?? existing?.processingStartedAt
+              : undefined,
+          })
+        }
+        for (const agentId of next.keys()) {
+          if (!seen.has(agentId)) next.delete(agentId)
         }
         return next
       })
@@ -243,6 +251,38 @@ export function useAgents() {
           summaryTokens: (data.summaryTokens as number | undefined) ?? existing?.summaryTokens,
           summaryBudgetTokens: (data.summaryBudgetTokens as number | undefined) ?? existing?.summaryBudgetTokens,
           keepPercent: (data.keepPercent as number | undefined) ?? existing?.keepPercent,
+        })
+        return next
+      })
+    },
+    'chat:done': (data) => {
+      const agentId = data.agentId as string
+      if (data.taskId || data.sessionId) return
+      // chat:done is the UI-level completion signal. If the trailing queue:update
+      // is missed/delayed, clear the spinner immediately while preserving the
+      // latest queue/context metadata until the next queue:update or refetch.
+      setAgentQueueState((prev) => {
+        const existing = prev.get(agentId)
+        if (!existing?.isProcessing) return prev
+        const next = new Map(prev)
+        next.set(agentId, {
+          ...existing,
+          isProcessing: false,
+          processingStartedAt: undefined,
+        })
+        return next
+      })
+    },
+    'agent:error': (data) => {
+      const agentId = data.agentId as string
+      setAgentQueueState((prev) => {
+        const existing = prev.get(agentId)
+        if (!existing?.isProcessing) return prev
+        const next = new Map(prev)
+        next.set(agentId, {
+          ...existing,
+          isProcessing: false,
+          processingStartedAt: undefined,
         })
         return next
       })

--- a/src/client/lib/tool-preview-renderers.test.ts
+++ b/src/client/lib/tool-preview-renderers.test.ts
@@ -22,6 +22,22 @@ describe('tool preview renderers', () => {
     }
   })
 
+  it('does not throw while non-file tool args are still pending', () => {
+    const pendingToolNames = [
+      'spawn_self',
+      'spawn_agent',
+      'task_todos',
+      'run_shell',
+      'add_mcp_server',
+    ]
+
+    for (const toolName of pendingToolNames) {
+      const renderer = getPreviewRenderer(toolName)
+      expect(renderer, toolName).toBeDefined()
+      expect(() => renderer?.({ toolName, args: undefined as unknown as Record<string, unknown>, status: 'pending' })).not.toThrow()
+    }
+  })
+
   it('keeps completed file previews when args exist', () => {
     expect(getPreviewRenderer('read_file')?.({ toolName: 'read_file', args: { path: 'src/app.ts' }, status: 'success' })).toBe('src/app.ts')
     expect(getPreviewRenderer('multi_edit')?.({
@@ -30,5 +46,16 @@ describe('tool preview renderers', () => {
       status: 'success',
     })).toBe('src/app.ts (2 edits)')
     expect(getPreviewRenderer('list_directory')?.({ toolName: 'list_directory', args: {}, status: 'pending' })).toBe('.')
+  })
+
+  it('keeps completed previews for title, todo, and command args', () => {
+    expect(getPreviewRenderer('spawn_self')?.({ toolName: 'spawn_self', args: { title: 'Investigate flaky renderer' }, status: 'success' })).toBe('Investigate flaky renderer')
+    expect(getPreviewRenderer('task_todos')?.({
+      toolName: 'task_todos',
+      args: { todos: [{ id: 'a', subject: 'Inspect', status: 'completed' }, { id: 'b', subject: 'Fix', status: 'pending' }] },
+      status: 'success',
+    })).toBe('1/2')
+    expect(getPreviewRenderer('run_shell')?.({ toolName: 'run_shell', args: { command: 'bun run typecheck' }, status: 'success' })).toBe('bun run typecheck')
+    expect(getPreviewRenderer('add_mcp_server')?.({ toolName: 'add_mcp_server', args: { name: 'filesystem', command: 'npx -y @modelcontextprotocol/server-filesystem' }, status: 'success' })).toBe('filesystem (npx -y @modelco…)')
   })
 })

--- a/src/client/lib/tool-preview-renderers.test.ts
+++ b/src/client/lib/tool-preview-renderers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test'
+import { getPreviewRenderer } from './tool-registry'
+import './tool-preview-renderers'
+
+describe('tool preview renderers', () => {
+  const fileToolNames = [
+    'read_file',
+    'write_file',
+    'edit_file',
+    'multi_edit',
+    'list_directory',
+    'write_mini_app_file',
+    'read_mini_app_file',
+    'delete_mini_app_file',
+  ]
+
+  it('does not throw while file tool args are still pending', () => {
+    for (const toolName of fileToolNames) {
+      const renderer = getPreviewRenderer(toolName)
+      expect(renderer, toolName).toBeDefined()
+      expect(() => renderer?.({ toolName, args: undefined as unknown as Record<string, unknown>, status: 'pending' })).not.toThrow()
+    }
+  })
+
+  it('keeps completed file previews when args exist', () => {
+    expect(getPreviewRenderer('read_file')?.({ toolName: 'read_file', args: { path: 'src/app.ts' }, status: 'success' })).toBe('src/app.ts')
+    expect(getPreviewRenderer('multi_edit')?.({
+      toolName: 'multi_edit',
+      args: { path: 'src/app.ts', edits: [{ oldText: 'a', newText: 'b' }, { oldText: 'c', newText: 'd' }] },
+      status: 'success',
+    })).toBe('src/app.ts (2 edits)')
+    expect(getPreviewRenderer('list_directory')?.({ toolName: 'list_directory', args: {}, status: 'pending' })).toBe('.')
+  })
+})

--- a/src/client/lib/tool-preview-renderers.test.ts
+++ b/src/client/lib/tool-preview-renderers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { getPreviewRenderer } from './tool-registry'
+import { FileEditRenderer } from '@/client/components/chat/renderers/FileEditRenderer'
+import { FileReadRenderer } from '@/client/components/chat/renderers/FileReadRenderer'
+import { FileWriteRenderer } from '@/client/components/chat/renderers/FileWriteRenderer'
 import './tool-preview-renderers'
 
 describe('tool preview renderers', () => {
@@ -19,6 +24,20 @@ describe('tool preview renderers', () => {
       const renderer = getPreviewRenderer(toolName)
       expect(renderer, toolName).toBeDefined()
       expect(() => renderer?.({ toolName, args: undefined as unknown as Record<string, unknown>, status: 'pending' })).not.toThrow()
+    }
+  })
+
+  it('keeps pending built-in file renderers out of failure state', () => {
+    const pendingProps = { args: { path: 'src/app.ts', content: 'hello', oldText: 'a', newText: 'b' }, result: undefined, status: 'pending' as const }
+
+    for (const [toolName, Renderer] of [
+      ['read_file', FileReadRenderer],
+      ['write_file', FileWriteRenderer],
+      ['edit_file', FileEditRenderer],
+    ] as const) {
+      const html = renderToStaticMarkup(createElement(Renderer, { toolName, ...pendingProps }))
+      expect(html.toLowerCase()).not.toContain('failed')
+      expect(html.toLowerCase()).not.toContain('error')
     }
   })
 

--- a/src/client/lib/tool-preview-renderers.ts
+++ b/src/client/lib/tool-preview-renderers.ts
@@ -9,44 +9,59 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + '…' : s
 }
 
+function getArg(args: Record<string, unknown> | null | undefined, key: string): unknown {
+  return args?.[key]
+}
+
+function getStringArg(args: Record<string, unknown> | null | undefined, key: string): string | undefined {
+  const value = getArg(args, key)
+  return typeof value === 'string' ? value : undefined
+}
+
+function getPathArg(args: Record<string, unknown> | null | undefined): string | null {
+  return getStringArg(args, 'path') || null
+}
+
 // --- Shell / system ---
 
 registerPreviewRenderer('run_shell', ({ args }) => {
-  const cmd = args.command as string | undefined
+  const cmd = getStringArg(args, 'command')
   return cmd ? truncate(cmd, 60) : null
 })
 
 registerPreviewRenderer('execute_sql', ({ args }) => {
-  return (args.sql as string) ? truncate(args.sql as string, 50) : null
+  const sql = getStringArg(args, 'sql')
+  return sql ? truncate(sql, 50) : null
 })
 
 // --- File operations ---
 
 registerPreviewRenderer('read_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('write_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('edit_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('multi_edit', ({ args }) => {
-  const path = args.path as string
-  const count = Array.isArray(args.edits) ? args.edits.length : undefined
+  const path = getPathArg(args)
+  const edits = getArg(args, 'edits')
+  const count = Array.isArray(edits) ? edits.length : undefined
   return path ? `${path}${count ? ` (${count} edits)` : ''}` : null
 })
 
 registerPreviewRenderer('list_directory', ({ args }) => {
-  return (args.path as string) || '.'
+  return getPathArg(args) || '.'
 })
 
 registerPreviewRenderer('grep', ({ args }) => {
-  const pattern = args.pattern as string
-  const glob = args.glob as string | undefined
+  const pattern = getStringArg(args, 'pattern')
+  const glob = getStringArg(args, 'glob')
   return pattern ? `"${truncate(pattern, 30)}"${glob ? ` in ${glob}` : ''}` : null
 })
 
@@ -312,7 +327,7 @@ registerPreviewRenderer('wake_me_in', ({ args }) => {
 // --- Mini apps ---
 
 registerPreviewRenderer('write_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('create_mini_app', ({ args }) => {
@@ -490,7 +505,7 @@ registerPreviewRenderer('uninstall_plugin', ({ args }) => {
 // --- Mini app file read ---
 
 registerPreviewRenderer('read_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 // --- Secret retrieval ---
@@ -616,7 +631,7 @@ registerPreviewRenderer('update_memory', ({ args }) => {
 // --- Mini app file deletion ---
 
 registerPreviewRenderer('delete_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 // --- Email ---

--- a/src/client/lib/tool-registry.ts
+++ b/src/client/lib/tool-registry.ts
@@ -37,7 +37,11 @@ export function getRenderer(toolName: string): ComponentType<ToolResultRendererP
 const previewRegistry = new Map<string, ToolPreviewFn>()
 
 export function registerPreviewRenderer(toolName: string, fn: ToolPreviewFn) {
-  previewRegistry.set(toolName, fn)
+  // chat:tool-call-start can render a preview before streamed tool args have
+  // arrived. Normalize here so every current/future preview renderer can read
+  // fields like args.title / args.todos / args.command without crashing while
+  // the call is still pending.
+  previewRegistry.set(toolName, (props) => fn({ ...props, args: props.args ?? {} }))
 }
 
 export function getPreviewRenderer(toolName: string): ToolPreviewFn | undefined {

--- a/src/server/channels/telegram.test.ts
+++ b/src/server/channels/telegram.test.ts
@@ -267,14 +267,17 @@ describe('shouldUsePolling', () => {
     expect(shouldUsePolling()).toBe(true)
   })
 
-  it('returns true when PUBLIC_URL is http (not https)', async () => {
+  it('gates on the configured URL scheme when PUBLIC_URL is set', async () => {
     process.env.PUBLIC_URL = 'http://myserver.com:3000'
     const { shouldUsePolling } = await import('@/server/channels/telegram')
-    // config.publicUrl is resolved at module load time and may be undefined in test,
-    // but with optional chaining the function no longer throws.
-    // The env var IS set, so the first check passes; config.publicUrl?.startsWith
-    // returns undefined (falsy) → result is true.
-    expect(shouldUsePolling()).toBe(true)
+    const { config } = await import('@/server/config')
+    // With PUBLIC_URL set, the first check is false, so the result is gated on
+    // whether the *configured* public URL (resolved at load time) is https.
+    // Assert against that rather than a fixed boolean: config.publicUrl reflects
+    // whatever PUBLIC_URL the config module was loaded with (undefined in a clean
+    // env → polling; an https URL on a real host → webhook), so a hard-coded
+    // expectation would be flaky depending on the ambient environment.
+    expect(shouldUsePolling()).toBe(!config.publicUrl?.startsWith('https://'))
   })
 
   it('returns false when PUBLIC_URL is https', async () => {

--- a/src/server/channels/telegram.test.ts
+++ b/src/server/channels/telegram.test.ts
@@ -267,27 +267,16 @@ describe('shouldUsePolling', () => {
     expect(shouldUsePolling()).toBe(true)
   })
 
-  it('gates on the configured URL scheme when PUBLIC_URL is set', async () => {
+  it('returns true when PUBLIC_URL is http', async () => {
     process.env.PUBLIC_URL = 'http://myserver.com:3000'
     const { shouldUsePolling } = await import('@/server/channels/telegram')
-    const { config } = await import('@/server/config')
-    // With PUBLIC_URL set, the first check is false, so the result is gated on
-    // whether the *configured* public URL (resolved at load time) is https.
-    // Assert against that rather than a fixed boolean: config.publicUrl reflects
-    // whatever PUBLIC_URL the config module was loaded with (undefined in a clean
-    // env → polling; an https URL on a real host → webhook), so a hard-coded
-    // expectation would be flaky depending on the ambient environment.
-    expect(shouldUsePolling()).toBe(!config.publicUrl?.startsWith('https://'))
+    expect(shouldUsePolling()).toBe(true)
   })
 
   it('returns false when PUBLIC_URL is https', async () => {
     process.env.PUBLIC_URL = 'https://myserver.com'
     const { shouldUsePolling } = await import('@/server/channels/telegram')
-    // PUBLIC_URL is set so first condition is false; config.publicUrl is undefined
-    // in test context, so ?.startsWith returns undefined (falsy) → !undefined = true.
-    // In production config.publicUrl would reflect the env var.
-    // Here we just verify it doesn't throw and returns a boolean.
-    expect(typeof shouldUsePolling()).toBe('boolean')
+    expect(shouldUsePolling()).toBe(false)
   })
 })
 

--- a/src/server/channels/telegram.ts
+++ b/src/server/channels/telegram.ts
@@ -67,7 +67,8 @@ async function telegramApi(token: string, method: string, body?: Record<string, 
 
 /** Returns true when no public HTTPS URL is configured (local/dev setup) */
 export function shouldUsePolling(): boolean {
-  return !process.env.PUBLIC_URL || !config.publicUrl?.startsWith('https://')
+  const publicUrl = process.env.PUBLIC_URL
+  return !publicUrl || !publicUrl.startsWith('https://')
 }
 
 interface TelegramPollingState {

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'bun:test'
 
 /**
  * Tests for src/server/config.ts
@@ -32,11 +32,19 @@ async function loadConfigWithEnv(env: Record<string, string | undefined>): Promi
   `
   // Serialize env for the in-process override (undefined → null for JSON)
   const serialized = JSON.stringify(env, (_, v) => v === undefined ? null : v)
+  // Hermetic base env: do NOT inherit the developer's ambient environment. A
+  // machine running Hivekeep exports config vars (HIVEKEEP_DATA_DIR, DB_PATH,
+  // TASKS_MAX_CONCURRENT, …) that would leak in and break default-value and
+  // override assertions. Start from a minimal env (just what the runtime needs)
+  // and layer only the test's explicit overrides on top.
+  const overrideEnv = Object.fromEntries(
+    Object.entries(env).filter(([, v]) => v !== undefined),
+  ) as Record<string, string>
   const proc = Bun.spawn([process.execPath, '-e', script, serialized], {
     cwd: process.cwd(),
     stdout: 'pipe',
     stderr: 'pipe',
-    env: { ...process.env, ...(Object.fromEntries(Object.entries(env).filter(([, v]) => v !== undefined)) as Record<string, string>) },
+    env: { PATH: process.env.PATH ?? '', HOME: process.env.HOME ?? '', ...overrideEnv },
   })
   const stdout = await new Response(proc.stdout).text()
   const stderr = await new Response(proc.stderr).text()
@@ -46,12 +54,12 @@ async function loadConfigWithEnv(env: Record<string, string | undefined>): Promi
 }
 
 describe('config', () => {
-  // For non-env-dependent tests, just import once
+  // Load config once, hermetically (clean env), so structure and default-value
+  // assertions reflect true defaults rather than the developer's ambient env.
+  // Env-override behaviour is covered by the subprocess tests below.
   let config: any
-  beforeEach(async () => {
-    // Dynamic import — uses current process env (won't change between tests without subprocess)
-    const mod = await import('./config.ts')
-    config = mod.config
+  beforeAll(async () => {
+    config = await loadConfigWithEnv({})
   })
 
   describe('structure', () => {

--- a/src/server/llm/llm/_anthropic-oauth-auth.ts
+++ b/src/server/llm/llm/_anthropic-oauth-auth.ts
@@ -46,27 +46,38 @@ const BUFFER_MS = 5 * 60 * 1000 // refresh 5 min before expiry
 /**
  * Resolve the real user home directory.
  * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer the REAL_HOME or the home from /etc/passwd via the USER env var.
+ * We prefer REAL_HOME, then a valid-looking env HOME (macOS /Users/ or Linux
+ * /home/), and only fall back to /home/$USER when nothing else is available.
  */
 function getRealHome(): string {
   // REAL_HOME is set by some snap environments
   if (process.env.REAL_HOME) return process.env.REAL_HOME
-  // Fall back to HOME, but strip snap paths
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
+  // Fall back to HOME, but strip snap paths and trust macOS /Users/... homes
+  const envHome = process.env.HOME ?? ''
+  const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
+  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
+    return envHome
+  }
   // Last resort: construct from USER
   if (process.env.USER) return `/home/${process.env.USER}`
-  return home
+  return envHome
 }
 
 const REAL_HOME = getRealHome()
 
-const CANDIDATE_PATHS = [
-  join(REAL_HOME, '.claude', '.credentials.json'),
-  join(REAL_HOME, '.claude.json'),
-  join(REAL_HOME, '.claude', 'credentials.json'),
-]
+// Consider both env HOME and snap-adjusted REAL_HOME so macOS /Users/... and
+// snap-sandboxed Linux both find their CLI credentials.
+const CANDIDATE_PATHS: string[] = []
+const envHomeForCandidates = process.env.HOME
+if (envHomeForCandidates && (envHomeForCandidates.startsWith('/Users/') || envHomeForCandidates.startsWith('/home/') || envHomeForCandidates === '/root')) {
+  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude', '.credentials.json'))
+  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude.json'))
+  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude', 'credentials.json'))
+}
+CANDIDATE_PATHS.push(join(REAL_HOME, '.claude', '.credentials.json'))
+CANDIDATE_PATHS.push(join(REAL_HOME, '.claude.json'))
+CANDIDATE_PATHS.push(join(REAL_HOME, '.claude', 'credentials.json'))
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/server/llm/llm/_anthropic-oauth-auth.ts
+++ b/src/server/llm/llm/_anthropic-oauth-auth.ts
@@ -57,7 +57,8 @@ function normalizeAbsoluteHome(home: string | undefined): string | null {
 
 function getRealHome(): string {
   // REAL_HOME is set by some snap environments
-  if (process.env.REAL_HOME) return process.env.REAL_HOME
+  const normalizedRealHome = normalizeAbsoluteHome(process.env.REAL_HOME)
+  if (normalizedRealHome) return normalizedRealHome
   // Fall back to HOME, but strip snap paths first.
   const envHome = process.env.HOME ?? ''
   const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
@@ -66,7 +67,7 @@ function getRealHome(): string {
   if (normalizedHome) return normalizedHome
   // Last resort: construct from USER
   if (process.env.USER) return `/home/${process.env.USER}`
-  return envHome
+  throw new Error('Unable to resolve an absolute home directory')
 }
 
 const REAL_HOME = getRealHome()

--- a/src/server/llm/llm/_anthropic-oauth-auth.ts
+++ b/src/server/llm/llm/_anthropic-oauth-auth.ts
@@ -28,7 +28,7 @@
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { createHash, randomBytes, randomUUID } from 'crypto'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import { createLogger } from '@/server/logger'
 
 const log = createLogger('provider:anthropic-oauth')
@@ -46,19 +46,24 @@ const BUFFER_MS = 5 * 60 * 1000 // refresh 5 min before expiry
 /**
  * Resolve the real user home directory.
  * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer REAL_HOME, then a valid-looking env HOME (macOS /Users/ or Linux
- * /home/), and only fall back to /home/$USER when nothing else is available.
+ * We prefer REAL_HOME, then any normalized absolute env HOME, and only fall
+ * back to /home/$USER when nothing else is available.
  */
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
 function getRealHome(): string {
   // REAL_HOME is set by some snap environments
   if (process.env.REAL_HOME) return process.env.REAL_HOME
-  // Fall back to HOME, but strip snap paths and trust macOS /Users/... homes
+  // Fall back to HOME, but strip snap paths first.
   const envHome = process.env.HOME ?? ''
   const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
-  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
-    return envHome
-  }
+  const normalizedHome = normalizeAbsoluteHome(envHome)
+  if (normalizedHome) return normalizedHome
   // Last resort: construct from USER
   if (process.env.USER) return `/home/${process.env.USER}`
   return envHome
@@ -66,18 +71,21 @@ function getRealHome(): string {
 
 const REAL_HOME = getRealHome()
 
-// Consider both env HOME and snap-adjusted REAL_HOME so macOS /Users/... and
-// snap-sandboxed Linux both find their CLI credentials.
+// Consider both env HOME and snap-adjusted REAL_HOME so macOS, nonstandard
+// Linux homes (e.g. /var/home/<user>), and snap-sandboxed Linux all work.
 const CANDIDATE_PATHS: string[] = []
-const envHomeForCandidates = process.env.HOME
-if (envHomeForCandidates && (envHomeForCandidates.startsWith('/Users/') || envHomeForCandidates.startsWith('/home/') || envHomeForCandidates === '/root')) {
-  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude', '.credentials.json'))
-  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude.json'))
-  CANDIDATE_PATHS.push(join(envHomeForCandidates, '.claude', 'credentials.json'))
+function addCandidate(path: string) {
+  if (!CANDIDATE_PATHS.includes(path)) CANDIDATE_PATHS.push(path)
 }
-CANDIDATE_PATHS.push(join(REAL_HOME, '.claude', '.credentials.json'))
-CANDIDATE_PATHS.push(join(REAL_HOME, '.claude.json'))
-CANDIDATE_PATHS.push(join(REAL_HOME, '.claude', 'credentials.json'))
+const envHomeForCandidates = normalizeAbsoluteHome(process.env.HOME)
+if (envHomeForCandidates) {
+  addCandidate(join(envHomeForCandidates, '.claude', '.credentials.json'))
+  addCandidate(join(envHomeForCandidates, '.claude.json'))
+  addCandidate(join(envHomeForCandidates, '.claude', 'credentials.json'))
+}
+addCandidate(join(REAL_HOME, '.claude', '.credentials.json'))
+addCandidate(join(REAL_HOME, '.claude.json'))
+addCandidate(join(REAL_HOME, '.claude', 'credentials.json'))
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/server/llm/llm/_codex-auth.ts
+++ b/src/server/llm/llm/_codex-auth.ts
@@ -11,7 +11,7 @@
  * against the user's ChatGPT subscription (Plus/Pro).
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import { createLogger } from '@/server/logger'
 
 const log = createLogger('provider:openai-codex')
@@ -27,29 +27,33 @@ const BUFFER_MS = 5 * 60 * 1000 // refresh 5 min before expiry
 /**
  * Resolve the real user home directory.
  * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer REAL_HOME, then a valid-looking env HOME (macOS /Users/ or Linux
- * /home/), and only fall back to /home/$USER when nothing else is available.
+ * We prefer REAL_HOME, then any normalized absolute env HOME, and only fall
+ * back to /home/$USER when nothing else is available.
  */
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
 function getRealHome(): string {
   if (process.env.REAL_HOME) return process.env.REAL_HOME
   const envHome = process.env.HOME ?? ''
   const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
-  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
-    return envHome
-  }
+  const normalizedHome = normalizeAbsoluteHome(envHome)
+  if (normalizedHome) return normalizedHome
   if (process.env.USER) return `/home/${process.env.USER}`
   return envHome
 }
 
 const REAL_HOME = getRealHome()
 
-// Always consider the actual $HOME (if it points somewhere useful) first so
-// macOS (/Users/<user>), non-snap Linux (/home/...), and snap-adjusted
-// REAL_HOME are all tried before giving up.
+// Always consider the actual $HOME first so macOS, nonstandard Linux homes
+// (e.g. /var/home/<user>), and snap-adjusted REAL_HOME are all tried.
 const CANDIDATE_PATHS: string[] = []
-const envHomeForCandidates = process.env.HOME
-if (envHomeForCandidates && (envHomeForCandidates.startsWith('/Users/') || envHomeForCandidates.startsWith('/home/') || envHomeForCandidates === '/root')) {
+const envHomeForCandidates = normalizeAbsoluteHome(process.env.HOME)
+if (envHomeForCandidates) {
   const p = join(envHomeForCandidates, '.codex', 'auth.json')
   if (!CANDIDATE_PATHS.includes(p)) CANDIDATE_PATHS.push(p)
 }

--- a/src/server/llm/llm/_codex-auth.ts
+++ b/src/server/llm/llm/_codex-auth.ts
@@ -27,22 +27,36 @@ const BUFFER_MS = 5 * 60 * 1000 // refresh 5 min before expiry
 /**
  * Resolve the real user home directory.
  * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer the REAL_HOME or the home from /etc/passwd via the USER env var.
+ * We prefer REAL_HOME, then a valid-looking env HOME (macOS /Users/ or Linux
+ * /home/), and only fall back to /home/$USER when nothing else is available.
  */
 function getRealHome(): string {
   if (process.env.REAL_HOME) return process.env.REAL_HOME
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
+  const envHome = process.env.HOME ?? ''
+  const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
+  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
+    return envHome
+  }
   if (process.env.USER) return `/home/${process.env.USER}`
-  return home
+  return envHome
 }
 
 const REAL_HOME = getRealHome()
 
-const CANDIDATE_PATHS = [
-  join(REAL_HOME, '.codex', 'auth.json'),
-]
+// Always consider the actual $HOME (if it points somewhere useful) first so
+// macOS (/Users/<user>), non-snap Linux (/home/...), and snap-adjusted
+// REAL_HOME are all tried before giving up.
+const CANDIDATE_PATHS: string[] = []
+const envHomeForCandidates = process.env.HOME
+if (envHomeForCandidates && (envHomeForCandidates.startsWith('/Users/') || envHomeForCandidates.startsWith('/home/') || envHomeForCandidates === '/root')) {
+  const p = join(envHomeForCandidates, '.codex', 'auth.json')
+  if (!CANDIDATE_PATHS.includes(p)) CANDIDATE_PATHS.push(p)
+}
+{
+  const p = join(REAL_HOME, '.codex', 'auth.json')
+  if (!CANDIDATE_PATHS.includes(p)) CANDIDATE_PATHS.push(p)
+}
 
 
 // ---------------------------------------------------------------------------

--- a/src/server/llm/llm/openai-codex.test.ts
+++ b/src/server/llm/llm/openai-codex.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test'
+import { STATIC_CODEX_MODELS, mapCodexModel } from './openai-codex'
+
+describe('STATIC_CODEX_MODELS (fallback catalog)', () => {
+  it('ships the curated Codex fallback slugs in probe/default order', () => {
+    const slugs = STATIC_CODEX_MODELS.map((m) => m.slug)
+    expect(slugs).toEqual(['gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'])
+    expect(slugs).not.toContain('gpt-5.4-mini')
+    expect(slugs[0]).toBe('gpt-5.5')
+    // All entries must be API-listable so resolveCodexModels surfaces them.
+    expect(STATIC_CODEX_MODELS.every((m) => m.supported_in_api && m.visibility === 'list')).toBe(true)
+  })
+
+  it('maps the first fallback to the live-confirmed GPT-5.5 probe/default model', () => {
+    const m = mapCodexModel(STATIC_CODEX_MODELS[0]!)
+    expect(m.id).toBe('gpt-5.5')
+    expect(m.name.length).toBeGreaterThan(0)
+    expect(m.contextWindow).toBeGreaterThan(0)
+    expect(m.thinking?.efforts).toEqual(['low', 'medium', 'high'])
+    expect(m.supportsImageInput).toBe(true)
+  })
+})

--- a/src/server/llm/llm/openai-codex.test.ts
+++ b/src/server/llm/llm/openai-codex.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { mkdirSync, rmSync, writeFileSync } from 'fs'
 import { STATIC_CODEX_MODELS, mapCodexModel } from './openai-codex'
 
 describe('STATIC_CODEX_MODELS (fallback catalog)', () => {
@@ -18,5 +19,36 @@ describe('STATIC_CODEX_MODELS (fallback catalog)', () => {
     expect(m.contextWindow).toBeGreaterThan(0)
     expect(m.thinking?.efforts).toEqual(['low', 'medium', 'high'])
     expect(m.supportsImageInput).toBe(true)
+  })
+
+  it('uses a nonstandard absolute HOME cache before falling back', async () => {
+    const home = '/tmp/hivekeep-codex-var-home'
+    const oldHome = process.env.HOME
+    const oldRealHome = process.env.REAL_HOME
+    try {
+      rmSync(home, { recursive: true, force: true })
+      mkdirSync(`${home}/.codex`, { recursive: true })
+      writeFileSync(`${home}/.codex/models_cache.json`, JSON.stringify({
+        models: [{
+          slug: 'gpt-test-cache',
+          display_name: 'GPT Test Cache',
+          supported_in_api: true,
+          visibility: 'list',
+          priority: 1,
+        }],
+      }))
+      process.env.HOME = home
+      delete process.env.REAL_HOME
+
+      const mod = await import(`./openai-codex?nonstandard-home=${Date.now()}`)
+      const models = mod.resolveCodexModels()
+      expect(models[0].slug).toBe('gpt-test-cache')
+    } finally {
+      if (oldHome === undefined) delete process.env.HOME
+      else process.env.HOME = oldHome
+      if (oldRealHome === undefined) delete process.env.REAL_HOME
+      else process.env.REAL_HOME = oldRealHome
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })

--- a/src/server/llm/llm/openai-codex.ts
+++ b/src/server/llm/llm/openai-codex.ts
@@ -17,7 +17,7 @@
  */
 
 import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import {
   getCodexOAuthCredentials,
   CODEX_BASE_URL,
@@ -64,26 +64,31 @@ const CONFIG_SCHEMA: readonly ConfigField[] = [
 
 // ─── Model discovery ─────────────────────────────────────────────────────────
 
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
 function getRealHome(): string {
   if (process.env.REAL_HOME) return process.env.REAL_HOME
   const envHome = process.env.HOME ?? ''
   const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
-  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
-    return envHome
-  }
+  const normalizedHome = normalizeAbsoluteHome(envHome)
+  if (normalizedHome) return normalizedHome
   if (process.env.USER) return `/home/${process.env.USER}`
   return envHome
 }
 
 const REAL_HOME = getRealHome()
 
-// Try the real env HOME first (handles macOS /Users/...) and the adjusted
-// snap-safe REAL_HOME as a fallback, so we never miss a valid cache.
+// Try the real env HOME first and the adjusted snap-safe REAL_HOME as a
+// fallback, so macOS and nonstandard Linux homes never miss a valid cache.
 function getModelsCacheCandidates(): string[] {
   const cands: string[] = []
-  const envHome = process.env.HOME
-  if (envHome && (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root')) {
+  const envHome = normalizeAbsoluteHome(process.env.HOME)
+  if (envHome) {
     const p = join(envHome, '.codex', 'models_cache.json')
     if (!cands.includes(p)) cands.push(p)
   }
@@ -115,7 +120,7 @@ interface CodexModelsCacheFile {
  * Returns null when the cache is missing or unreadable (so the caller can
  * decide whether to error out or fall back).
  */
-function readCodexModelsFromCache(): CodexModelCacheEntry[] | null {
+export function readCodexModelsFromCache(): CodexModelCacheEntry[] | null {
   for (const p of MODELS_CACHE_CANDIDATES) {
     try {
       if (!existsSync(p)) continue
@@ -155,7 +160,7 @@ export const STATIC_CODEX_MODELS: CodexModelCacheEntry[] = [
 ]
 
 /** Catalog entries from the CLI cache when present, else the static fallback. */
-function resolveCodexModels(): CodexModelCacheEntry[] {
+export function resolveCodexModels(): CodexModelCacheEntry[] {
   return readCodexModelsFromCache() ?? STATIC_CODEX_MODELS
 }
 

--- a/src/server/llm/llm/openai-codex.ts
+++ b/src/server/llm/llm/openai-codex.ts
@@ -66,15 +66,34 @@ const CONFIG_SCHEMA: readonly ConfigField[] = [
 
 function getRealHome(): string {
   if (process.env.REAL_HOME) return process.env.REAL_HOME
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
+  const envHome = process.env.HOME ?? ''
+  const snapMatch = envHome.match(/^(\/home\/[^/]+)\/snap\//)
   if (snapMatch) return snapMatch[1]!
+  if (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root') {
+    return envHome
+  }
   if (process.env.USER) return `/home/${process.env.USER}`
-  return home
+  return envHome
 }
 
 const REAL_HOME = getRealHome()
-const MODELS_CACHE_PATH = join(REAL_HOME, '.codex', 'models_cache.json')
+
+// Try the real env HOME first (handles macOS /Users/...) and the adjusted
+// snap-safe REAL_HOME as a fallback, so we never miss a valid cache.
+function getModelsCacheCandidates(): string[] {
+  const cands: string[] = []
+  const envHome = process.env.HOME
+  if (envHome && (envHome.startsWith('/Users/') || envHome.startsWith('/home/') || envHome === '/root')) {
+    const p = join(envHome, '.codex', 'models_cache.json')
+    if (!cands.includes(p)) cands.push(p)
+  }
+  {
+    const p = join(REAL_HOME, '.codex', 'models_cache.json')
+    if (!cands.includes(p)) cands.push(p)
+  }
+  return cands
+}
+const MODELS_CACHE_CANDIDATES = getModelsCacheCandidates()
 
 interface CodexModelCacheEntry {
   slug: string
@@ -97,24 +116,47 @@ interface CodexModelsCacheFile {
  * decide whether to error out or fall back).
  */
 function readCodexModelsFromCache(): CodexModelCacheEntry[] | null {
-  try {
-    if (!existsSync(MODELS_CACHE_PATH)) return null
-    const raw = readFileSync(MODELS_CACHE_PATH, 'utf8')
-    const parsed = JSON.parse(raw) as CodexModelsCacheFile
-    if (!parsed.models || !Array.isArray(parsed.models)) return null
-    const filtered = parsed.models.filter(
-      (m) =>
-        typeof m.slug === 'string' &&
-        m.slug.length > 0 &&
-        m.supported_in_api === true &&
-        m.visibility === 'list' &&
-        m.upgrade == null,
-    )
-    filtered.sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
-    return filtered
-  } catch {
-    return null
+  for (const p of MODELS_CACHE_CANDIDATES) {
+    try {
+      if (!existsSync(p)) continue
+      const raw = readFileSync(p, 'utf8')
+      const parsed = JSON.parse(raw) as CodexModelsCacheFile
+      if (!parsed.models || !Array.isArray(parsed.models)) continue
+      const filtered = parsed.models.filter(
+        (m) =>
+          typeof m.slug === 'string' &&
+          m.slug.length > 0 &&
+          m.supported_in_api === true &&
+          m.visibility === 'list' &&
+          m.upgrade == null,
+      )
+      filtered.sort((a, b) => (a.priority ?? 999) - (b.priority ?? 999))
+      if (filtered.length > 0) return filtered
+    } catch {
+      // try the next candidate path
+    }
   }
+  return null
+}
+
+/**
+ * Static fallback catalog used whenever the CLI cache (`~/.codex/models_cache.json`)
+ * is absent. Codex OAuth does not expose a reliable model-list API, so the CLI
+ * cache is preferred whenever it exists. Keep `gpt-5.5` first: it is the
+ * live-confirmed gateway probe and default candidate used when authenticating or
+ * choosing the first model. Do not add visible picker models (for example,
+ * `gpt-5.4-mini`) unless they have been verified against the Codex backend API.
+ */
+export const STATIC_CODEX_MODELS: CodexModelCacheEntry[] = [
+  { slug: 'gpt-5.5', display_name: 'GPT-5.5', context_window: 400000, max_output_tokens: 128000, supported_in_api: true, visibility: 'list' },
+  { slug: 'gpt-5.4', display_name: 'GPT-5.4', context_window: 400000, max_output_tokens: 128000, supported_in_api: true, visibility: 'list' },
+  { slug: 'gpt-5.3-codex', display_name: 'GPT-5.3 Codex', context_window: 400000, max_output_tokens: 128000, supported_in_api: true, visibility: 'list' },
+  { slug: 'gpt-5.3-codex-spark', display_name: 'GPT-5.3 Codex Spark', context_window: 400000, max_output_tokens: 128000, supported_in_api: true, visibility: 'list' },
+]
+
+/** Catalog entries from the CLI cache when present, else the static fallback. */
+function resolveCodexModels(): CodexModelCacheEntry[] {
+  return readCodexModelsFromCache() ?? STATIC_CODEX_MODELS
 }
 
 /**
@@ -122,7 +164,7 @@ function readCodexModelsFromCache(): CodexModelCacheEntry[] | null {
  * accepts `reasoning_effort` — the cache does not expose the supported
  * levels explicitly, so we assume the standard OpenAI set (no `max`).
  */
-function mapCodexModel(entry: CodexModelCacheEntry): LLMModel {
+export function mapCodexModel(entry: CodexModelCacheEntry): LLMModel {
   const model: LLMModel = {
     id: entry.slug,
     name: entry.display_name && entry.display_name.length > 0 ? entry.display_name : entry.slug,
@@ -447,13 +489,9 @@ export const openaiCodexProvider: LLMProvider = {
     try {
       const overridePath = config['authFilePath'] || undefined
       const { accessToken, accountId } = await getCodexOAuthCredentials(overridePath)
-      const entries = readCodexModelsFromCache()
-      const testModel = entries?.[0]?.slug
+      const testModel = resolveCodexModels()[0]?.slug
       if (!testModel) {
-        return {
-          valid: false,
-          error: 'Codex model catalog cache is missing — run `codex login` once to seed it.',
-        }
+        return { valid: false, error: 'No Codex models available to test against.' }
       }
       // Lightweight ping with a short instruction; consumed and discarded.
       const response = await fetch(`${CODEX_BASE_URL}/responses`, {
@@ -492,13 +530,9 @@ export const openaiCodexProvider: LLMProvider = {
   },
 
   async listModels(_config: ProviderConfig): Promise<LLMModel[]> {
-    const entries = readCodexModelsFromCache()
-    if (!entries) {
-      throw new ProviderServerError(
-        'Codex model catalog cache missing at ~/.codex/models_cache.json. Run `codex login` once to seed it.',
-      )
-    }
-    return entries.map(mapCodexModel)
+    // CLI cache when present, else the static fallback so setups can list models
+    // before the Codex CLI has seeded ~/.codex/models_cache.json.
+    return resolveCodexModels().map(mapCodexModel)
   },
 
   chat(model, request, config) {

--- a/src/server/routes/messages.ts
+++ b/src/server/routes/messages.ts
@@ -268,13 +268,15 @@ messageRoutes.get('/', async (c) => {
   // live snapshot so a client mounting mid-stream can seed its streaming
   // bubble immediately instead of staring at a typing indicator until
   // `chat:done` fires. Same pattern as `getActiveTaskSnapshot()` for tasks.
-  // Note: unlike sub-task streams, the main-thread row is only inserted at
-  // the END of the turn, so the streaming messageId is NEVER in `messageList`
-  // and never needs to be overlay-merged with a persisted row.
+  // The main-thread assistant row is now pre-inserted for crash recovery, so
+  // suppress the separate streaming overlay when that row is already included
+  // in this page; the persisted row carries checkpointed tool calls and the
+  // SSE stream continues to update it client-side.
   // Skipped on paginated (?before=) queries — they fetch older history and
   // the in-flight bubble (if any) belongs to the initial-fetch caller.
   const streamSnapshot = !before ? getActiveAgentStreamSnapshot(agentId) : undefined
-  const streamingMessage = streamSnapshot
+  const streamMessageAlreadyListed = !!streamSnapshot && messageList.some((m) => m.id === streamSnapshot.messageId)
+  const streamingMessage = streamSnapshot && !streamMessageAlreadyListed
     ? {
         messageId: streamSnapshot.messageId,
         content: streamSnapshot.content,

--- a/src/server/routes/messages.ts
+++ b/src/server/routes/messages.ts
@@ -300,6 +300,12 @@ messageRoutes.get('/', async (c) => {
       try { toolCalls = m.toolCalls ? JSON.parse(m.toolCalls as string) : null } catch { /* corrupted toolCalls */ }
       try { reasoning = m.reasoning ? JSON.parse(m.reasoning as string) : null } catch { /* corrupted reasoning */ }
 
+      const liveSnapshot = streamSnapshot?.messageId === m.id ? streamSnapshot : null
+      if (liveSnapshot) {
+        if (liveSnapshot.toolCalls.length > 0) toolCalls = liveSnapshot.toolCalls
+        if (liveSnapshot.reasoning.length > 0) reasoning = liveSnapshot.reasoning
+      }
+
       // Channel context line: inbound was persisted at top-level
       // (channelContextLine); outbound under channelDelivery.contextLine.
       const channelDelivery = meta?.channelDelivery as { contextLine?: string } | undefined
@@ -354,7 +360,7 @@ messageRoutes.get('/', async (c) => {
       return {
         id: m.id,
         role: m.role,
-        content: m.content,
+        content: liveSnapshot?.content ?? m.content,
         sourceType: m.sourceType,
         sourceId: m.sourceId,
         sourceName: agentInfo?.name ?? null,

--- a/src/server/services/agent-engine.ts
+++ b/src/server/services/agent-engine.ts
@@ -83,6 +83,11 @@ const PROTECTED_CORE_TOOLS = new Set<string>([
   'grep',
   'list_providers',
   'list_models',
+  // High-impact platform controls can sit late in the registry/toolbox order
+  // (e.g. Queenie's configurator + all toolbox set on OpenAI-compatible caps).
+  // If the cap pass drops restart_platform, the UI/catalog still show it as
+  // granted while the LLM never receives a callable schema.
+  'restart_platform',
 ])
 
 /**
@@ -191,6 +196,8 @@ function capTools(
  * without executing them. This allows our custom loop to execute tools
  * sequentially between LLM steps, preventing hallucinated tool results.
  */
+export const __testCapTools = capTools
+
 function stripToolExecute(tools: Record<string, Tool>): Record<string, Tool> {
   const schemas: Record<string, Tool> = {}
   for (const [name, t] of Object.entries(tools)) {

--- a/src/server/services/agent-engine.ts
+++ b/src/server/services/agent-engine.ts
@@ -947,8 +947,10 @@ export async function processNextMessage(agentId: string): Promise<boolean> {
   if (compactingAgents.has(agentId)) return false
   agentLocks.add(agentId)
 
-  // Hoisted so the finally block can guarantee cleanup
+  // Hoisted so the finally/catch blocks can guarantee cleanup.
   let queueItem: Awaited<ReturnType<typeof dequeueMessage>> = null
+  let assistantMessageIdForCleanup: string | null = null
+  let assistantMessageHasCheckpoint = false
 
   try {
     // Don't process if already processing (DB-level check, main slot only)
@@ -1576,6 +1578,23 @@ export async function processNextMessage(agentId: string): Promise<boolean> {
     }
     activeAgentStreams.set(agentId, agentStreamSnapshot)
 
+    // Pre-insert the assistant row before any tool execution. Main-thread turns
+    // used to persist only at the very end; if a tool (notably restart_platform)
+    // exited the process mid-turn, boot recovery saw only the user message and
+    // re-ran the same instruction. The row is updated at tool-batch boundaries
+    // and finalized below, matching the crash-safe task runner pattern.
+    await db.insert(messages).values({
+      id: assistantMessageId,
+      agentId,
+      role: 'assistant',
+      content: '',
+      sourceType: 'agent',
+      sourceId: agentId,
+      channelOriginId: queueItem.channelOriginId ?? null,
+      createdAt: new Date(),
+    })
+    assistantMessageIdForCleanup = assistantMessageId
+
     // Convert tools to hivekeep shape once (provider.chat() handles them natively).
     // markLastHivekeepToolCacheable adds the per-tool cache_control hint Anthropic
     // uses to cache the whole tools block as a single prefix.
@@ -1703,6 +1722,22 @@ export async function processNextMessage(agentId: string): Promise<boolean> {
         assistantMessageId,
       })
       toolCallsLog.push(...batch.toolCallsLog)
+
+      // Crash-safety checkpoint: persist committed tool actions/results before
+      // asking the model for the next step. If a tool schedules process exit
+      // (restart_platform), the resumed queue item will include the assistant
+      // tool-use/result context instead of replaying only the user's permission.
+      if (batch.toolCallsLog.length > 0) {
+        await db.update(messages)
+          .set({
+            content: fullContent,
+            toolCalls: JSON.stringify(toolCallsLog),
+            reasoning: reasoningSegments.length > 0 ? JSON.stringify(reasoningSegments) : null,
+          })
+          .where(eq(messages.id, assistantMessageId))
+        assistantMessageHasCheckpoint = true
+      }
+
       if (batch.wasAborted) { wasAborted = true; break }
 
       // Append assistant message (with tool calls) + tool results to history
@@ -1852,41 +1887,37 @@ export async function processNextMessage(agentId: string): Promise<boolean> {
       })
     }
 
-    // Save assistant message (partial if aborted) with tool call metadata.
-    // Do NOT persist when the row would carry no text AND no tool calls:
-    // Anthropic rejects empty text content blocks ("text content blocks
-    // must be non-empty") on the next turn, which permanently blocks the
-    // conversation until the empty row is removed. The chat:done SSE below
-    // still fires so the UI exits its typing state cleanly.
+    // Finalize the pre-inserted assistant message (partial if aborted) with
+    // tool call metadata. Delete it if it would carry no text AND no tool
+    // calls: Anthropic rejects empty text content blocks on the next turn.
     if (fullContent || toolCallsLog.length > 0) {
-      await db.insert(messages).values({
-        id: assistantMessageId,
-        agentId,
-        role: 'assistant',
-        content: fullContent || '',
-        sourceType: 'agent',
-        sourceId: agentId,
-        toolCalls: toolCallsLog.length > 0 ? JSON.stringify(toolCallsLog) : null,
-        channelOriginId: queueItem.channelOriginId ?? null,
-        reasoning: reasoningSegments.length > 0 ? JSON.stringify(reasoningSegments) : null,
-        metadata: (() => {
-          const meta: Record<string, unknown> = {}
-          if (relevantMemories.length > 0) meta.injectedMemories = relevantMemories
-          if (stepLimitReached) {
-            meta.stepLimitReached = true
-            meta.maxSteps = config.tools.maxSteps
-            meta.toolCallCount = toolCallsLog.length
-          }
-          if (emptyTurn) {
-            meta.emptyTurn = true
-            meta.finishReason = lastFinishReason
-          }
-          if (silentStopAfterTools) meta.silentStop = true
-          if (tokenUsage) meta.tokenUsage = tokenUsage
-          return Object.keys(meta).length > 0 ? JSON.stringify(meta) : null
-        })(),
-        createdAt: new Date(),
-      })
+      await db.update(messages)
+        .set({
+          content: fullContent || '',
+          toolCalls: toolCallsLog.length > 0 ? JSON.stringify(toolCallsLog) : null,
+          reasoning: reasoningSegments.length > 0 ? JSON.stringify(reasoningSegments) : null,
+          metadata: (() => {
+            const meta: Record<string, unknown> = {}
+            if (relevantMemories.length > 0) meta.injectedMemories = relevantMemories
+            if (stepLimitReached) {
+              meta.stepLimitReached = true
+              meta.maxSteps = config.tools.maxSteps
+              meta.toolCallCount = toolCallsLog.length
+            }
+            if (emptyTurn) {
+              meta.emptyTurn = true
+              meta.finishReason = lastFinishReason
+            }
+            if (silentStopAfterTools) meta.silentStop = true
+            if (tokenUsage) meta.tokenUsage = tokenUsage
+            return Object.keys(meta).length > 0 ? JSON.stringify(meta) : null
+          })(),
+        })
+        .where(eq(messages.id, assistantMessageId))
+      assistantMessageHasCheckpoint = true
+    } else {
+      await db.delete(messages).where(eq(messages.id, assistantMessageId))
+      assistantMessageIdForCleanup = null
     }
 
     // Emit chat:done SSE event (include source metadata so the client can
@@ -2024,6 +2055,13 @@ export async function processNextMessage(agentId: string): Promise<boolean> {
     const displayError = friendlyErrorMessage(errorMsg)
 
     log.error({ agentId, error: errorMsg }, 'Agent engine error')
+
+    // If the turn failed before any meaningful assistant/tool checkpoint, remove
+    // the pre-inserted empty row so it does not leave a blank bubble in history.
+    if (assistantMessageIdForCleanup && !assistantMessageHasCheckpoint) {
+      await db.delete(messages).where(eq(messages.id, assistantMessageIdForCleanup)).catch(() => {})
+      assistantMessageIdForCleanup = null
+    }
 
     // Recovery: if the main LLM call failed because the prompt exceeded the
     // model's context window (a state we should normally avoid via the 75%

--- a/src/server/services/agent-engine.ts
+++ b/src/server/services/agent-engine.ts
@@ -2177,7 +2177,7 @@ export const QUICK_SESSION_EXCLUDED_TOOLS = new Set([
   // Channels (proactive messaging not available in quick sessions)
   'send_channel_message', 'list_channel_conversations',
   // Platform
-  'get_platform_logs',
+  'get_platform_logs', 'restart_platform',
   // Memory WRITE (read-only in quick sessions)
   'memorize', 'update_memory', 'forget',
 ])

--- a/src/server/services/tool-cap-protection.test.ts
+++ b/src/server/services/tool-cap-protection.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test'
 import { tool } from '@/server/tools/tool-helper'
-import { __testCapTools } from '@/server/services/agent-engine'
+import { __testCapTools, QUICK_SESSION_EXCLUDED_TOOLS } from '@/server/services/agent-engine'
 
 function fakeTools(names: string[]) {
   return Object.fromEntries(
@@ -16,7 +16,7 @@ function fakeTools(names: string[]) {
 }
 
 describe('agent-engine tool cap protection', () => {
-  it('keeps restart_platform when a broad toolset exceeds the provider cap', () => {
+  it('keeps restart_platform when explicitly granted and a broad toolset exceeds the provider cap', () => {
     const names = [
       'read_file',
       'write_file',
@@ -35,5 +35,9 @@ describe('agent-engine tool cap protection', () => {
     expect(capped.restart_platform).toBeDefined()
     expect(capped.read_file).toBeDefined()
     expect(capped.write_file).toBeDefined()
+  })
+
+  it('excludes restart_platform from quick sessions before provider cap handling', () => {
+    expect(QUICK_SESSION_EXCLUDED_TOOLS.has('restart_platform')).toBe(true)
   })
 })

--- a/src/server/services/tool-cap-protection.test.ts
+++ b/src/server/services/tool-cap-protection.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'bun:test'
+import { tool } from '@/server/tools/tool-helper'
+import { __testCapTools } from '@/server/services/agent-engine'
+
+function fakeTools(names: string[]) {
+  return Object.fromEntries(
+    names.map((name) => [
+      name,
+      tool({
+        description: name,
+        inputSchema: undefined as any,
+        execute: async () => null,
+      }),
+    ]),
+  )
+}
+
+describe('agent-engine tool cap protection', () => {
+  it('keeps restart_platform when a broad toolset exceeds the provider cap', () => {
+    const names = [
+      'read_file',
+      'write_file',
+      ...Array.from({ length: 130 }, (_, i) => `zz_droppable_${i}`),
+      'restart_platform',
+    ]
+
+    const capped = __testCapTools(
+      fakeTools(names),
+      'agent-1',
+      'test-provider',
+      { maxTools: 128 },
+    )
+
+    expect(Object.keys(capped)).toHaveLength(128)
+    expect(capped.restart_platform).toBeDefined()
+    expect(capped.read_file).toBeDefined()
+    expect(capped.write_file).toBeDefined()
+  })
+})

--- a/src/server/services/toolboxes.test.ts
+++ b/src/server/services/toolboxes.test.ts
@@ -169,4 +169,21 @@ describe('resolveToolboxNames — "*" wildcard', () => {
     expect(resolved).toEqual([NATIVE_TOOL])
     expect(resolved).not.toContain('custom_enabled_one')
   })
+
+  itReal('filters default-disabled native tools out of toolbox grants while preserving explicit names for metadata', async () => {
+    const { filterToolboxGrantedToolNames } = await import('@/server/services/toolset-resolver')
+    const DEFAULT_DISABLED_TOOL = '__toolbox_default_disabled_test__'
+    toolRegistry.register(DEFAULT_DISABLED_TOOL, { ...fakeTool(), defaultDisabled: true }, 'system')
+    try {
+      const box = createToolbox({ name: 'default-disabled-test', toolNames: [NATIVE_TOOL, DEFAULT_DISABLED_TOOL] })
+      const resolved = resolveToolboxNames([box.id])
+
+      expect(resolved).toContain(NATIVE_TOOL)
+      expect(resolved).toContain(DEFAULT_DISABLED_TOOL)
+      expect(filterToolboxGrantedToolNames(resolved)).toContain(NATIVE_TOOL)
+      expect(filterToolboxGrantedToolNames(resolved)).not.toContain(DEFAULT_DISABLED_TOOL)
+    } finally {
+      toolRegistry.unregister(DEFAULT_DISABLED_TOOL)
+    }
+  })
 })

--- a/src/server/services/toolset-resolver.ts
+++ b/src/server/services/toolset-resolver.ts
@@ -12,8 +12,8 @@
  *            + the Agent's custom tools      (resolveCustomTools)
  *
  *   allowed  = CORE_TOOLS ∪ resolveToolboxNames(toolboxIds)
- *              where a null/empty toolbox selection resolves to the 'all'
- *              built-in (by NAME, at runtime — never a SQL backfill).
+ *              where defaultDisabled native tools are grantable only through
+ *              CORE_TOOLS or explicit per-Agent grants, never broad toolboxes.
  *
  *   toolset  = { name ∈ universe | name ∈ allowed }
  *
@@ -96,6 +96,10 @@ export function resolveAgentToolboxIds(
   return ids
 }
 
+export function filterToolboxGrantedToolNames(names: string[]): string[] {
+  return names.filter((name) => !toolRegistry.isDefaultDisabled(name) || CORE_TOOLS.includes(name))
+}
+
 export interface ResolveToolsetOptions {
   agentId: string
   /** Raw toolbox selection from the Agent or task row (JSON string, array, or
@@ -169,9 +173,15 @@ export async function resolveToolset(
   // requests). "*" → all native + all enabled custom. Extras are fetched here
   // (not threaded by callers) so every resolution path honours them; the
   // sub-Agent hard floor below still subtracts as usual.
+  //
+  // Native tools with registration.defaultDisabled are intentionally NOT granted
+  // by toolbox membership (including the broad "all" wildcard or built-in
+  // configurator toolbox). They require an explicit per-Agent grant so the UI's
+  // "disabled by default" metadata cannot silently fail open at runtime.
   const resolvedIds = resolveAgentToolboxIds(toolboxIds, { ticketId: ticketId ?? null })
-  const allowed = new Set<string>([...CORE_TOOLS, ...resolveToolboxNames(resolvedIds)])
-  for (const name of await getAgentExtraToolNames(agentId)) allowed.add(name)
+  const toolboxAllowed = filterToolboxGrantedToolNames(resolveToolboxNames(resolvedIds))
+  const extraToolNames = await getAgentExtraToolNames(agentId)
+  const allowed = new Set<string>([...CORE_TOOLS, ...toolboxAllowed, ...extraToolNames])
 
   // ── Filter universe → toolset ─────────────────────────────────────────────────
   const toolset: Record<string, Tool<any, any>> = {}

--- a/src/server/tools/index.test.ts
+++ b/src/server/tools/index.test.ts
@@ -151,6 +151,18 @@ describe('ToolRegistry', () => {
     expect(registry.list()[0]!.defaultDisabled).toBe(false)
   })
 
+  it('singleton exposes defaultDisabled metadata for runtime grant filtering', async () => {
+    const { toolRegistry } = await import('@/server/tools/index')
+    const name = '__default_disabled_runtime_test__'
+    toolRegistry.register(name, makeMockRegistration(['main'], { defaultDisabled: true }), 'system')
+    try {
+      expect(toolRegistry.isDefaultDisabled(name)).toBe(true)
+      expect(toolRegistry.isDefaultDisabled('__missing_tool__')).toBe(false)
+    } finally {
+      toolRegistry.unregister(name)
+    }
+  })
+
   // ─── resolve: availability filtering ─────────────────────────────────
 
   it('resolve returns only main-available tools for main context', () => {

--- a/src/server/tools/index.ts
+++ b/src/server/tools/index.ts
@@ -116,6 +116,10 @@ class ToolRegistry {
    *  placeholder passes through as inert text (correct for tools whose
    *  output re-enters LLM context, e.g. memorize). Custom/MCP tools are
    *  handled by the executor — they always expand. */
+  isDefaultDisabled(name: string): boolean {
+    return this.tools.get(name)?.registration.defaultDisabled === true
+  }
+
   expandsSecrets(name: string): boolean {
     return this.tools.get(name)?.registration.expandsSecrets === true
   }

--- a/src/server/tools/platform-tools.test.ts
+++ b/src/server/tools/platform-tools.test.ts
@@ -38,6 +38,23 @@ mock.module('@/server/logger', () => ({
 // Note: we do NOT mock @/server/services/log-store to avoid polluting other test files.
 // Instead, we import the real logStore and rely on it being functional for getPlatformLogsTool tests.
 
+let mockHumanPromptRows: Array<Record<string, unknown>> = []
+
+const mockDb = {
+  select: () => ({
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          all: async () => mockHumanPromptRows,
+        }),
+        all: async () => mockHumanPromptRows,
+      }),
+    }),
+  }),
+}
+
+mock.module('@/server/db/index', () => ({ db: mockDb, sqlite: {} }))
+
 // Import after mocks
 const {
   getPlatformLogsTool,
@@ -60,6 +77,21 @@ async function execute(registration: ToolRegistration, params: Record<string, un
   return t.execute(params, { messages: [], toolCallId: 'test' })
 }
 
+function seedRestartConfirmation(overrides: Record<string, unknown> = {}) {
+  mockHumanPromptRows.push({
+    id: 'prompt-restart',
+    agentId: CTX.agentId,
+    taskId: null,
+    promptType: 'confirm',
+    question: 'Restart Hivekeep now?',
+    description: 'Confirm platform restart',
+    response: JSON.stringify('yes'),
+    status: 'answered',
+    respondedAt: new Date(),
+    ...overrides,
+  })
+}
+
 // ─── Setup / Teardown ────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -69,6 +101,7 @@ beforeEach(() => {
   mockConfig.environment.envFilePath = TEST_ENV_FILE
   mockConfig.environment.serviceFilePath = null
   mockConfig.isDocker = false
+  mockHumanPromptRows = []
 })
 
 afterEach(() => {
@@ -434,6 +467,24 @@ describe('restartPlatformTool', () => {
     expect(result.success).toBe(false)
     expect(result.error).toContain('prompt_human(confirm)')
     expect(result.error).toContain('confirmed=true')
+  })
+
+  it('rejects manual installations after a valid restart confirmation', async () => {
+    mockConfig.environment.installationType = 'manual'
+    for (let i = 0; i < 6; i++) {
+      seedRestartConfirmation({
+        id: `prompt-${i}`,
+        question: i === 5 ? 'Restart Hivekeep now?' : 'Confirm unrelated action?',
+        description: i === 5 ? 'Confirm platform restart' : 'Not about restarting',
+      })
+    }
+
+    const result = await execute(restartPlatformTool as ToolRegistration, {
+      reason: 'testing',
+      confirmed: true,
+    })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('manually')
   })
 
   // Note: we don't test the actual restart (process.exit) to avoid killing the test runner

--- a/src/server/tools/platform-tools.test.ts
+++ b/src/server/tools/platform-tools.test.ts
@@ -40,15 +40,65 @@ mock.module('@/server/logger', () => ({
 
 let mockHumanPromptRows: Array<Record<string, unknown>> = []
 
+function collectEqFilters(predicate: unknown): Record<string, unknown> {
+  const filters: Record<string, unknown> = {}
+
+  function visit(node: unknown) {
+    if (!node || typeof node !== 'object') return
+    const chunks = (node as { queryChunks?: unknown[] }).queryChunks
+    if (Array.isArray(chunks)) {
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i]
+        if (!chunk || typeof chunk !== 'object') {
+          visit(chunk)
+          continue
+        }
+        const columnName = (chunk as { name?: unknown }).name
+        if (typeof columnName === 'string') {
+          const param = chunks.slice(i + 1, i + 4).find((candidate) => {
+            return !!candidate && typeof candidate === 'object' && 'value' in candidate && !Array.isArray((candidate as { value?: unknown }).value)
+          }) as { value?: unknown } | undefined
+          if (param) filters[columnName] = param.value
+        }
+        visit(chunk)
+      }
+    }
+  }
+
+  visit(predicate)
+  return filters
+}
+
+function applyHumanPromptFilters(rows: Array<Record<string, unknown>>, predicate: unknown) {
+  const filters = collectEqFilters(predicate)
+  const columnToRowKey: Record<string, string> = {
+    id: 'id',
+    agent_id: 'agentId',
+    status: 'status',
+    prompt_type: 'promptType',
+  }
+
+  return rows.filter((row) => {
+    for (const [column, expected] of Object.entries(filters)) {
+      const rowKey = columnToRowKey[column]
+      if (rowKey && row[rowKey] !== expected) return false
+    }
+    return true
+  })
+}
+
 const mockDb = {
   select: () => ({
     from: () => ({
-      where: () => ({
-        orderBy: () => ({
-          all: async () => mockHumanPromptRows,
-        }),
-        all: async () => mockHumanPromptRows,
-      }),
+      where: (predicate: unknown) => {
+        const filteredRows = () => applyHumanPromptFilters(mockHumanPromptRows, predicate)
+        return {
+          orderBy: () => ({
+            all: async () => filteredRows(),
+          }),
+          all: async () => filteredRows(),
+        }
+      },
     }),
   }),
 }

--- a/src/server/tools/platform-tools.test.ts
+++ b/src/server/tools/platform-tools.test.ts
@@ -425,14 +425,15 @@ describe('restartPlatformTool', () => {
     expect(result.error).toContain('not confirmed')
   })
 
-  it('rejects restart for manual installations', async () => {
+  it('rejects confirmed=true without a platform human confirmation', async () => {
     mockConfig.environment.installationType = 'manual'
     const result = await execute(restartPlatformTool as ToolRegistration, {
       reason: 'testing',
       confirmed: true,
     })
     expect(result.success).toBe(false)
-    expect(result.error).toContain('manually')
+    expect(result.error).toContain('prompt_human(confirm)')
+    expect(result.error).toContain('confirmed=true')
   })
 
   // Note: we don't test the actual restart (process.exit) to avoid killing the test runner

--- a/src/server/tools/platform-tools.ts
+++ b/src/server/tools/platform-tools.ts
@@ -17,11 +17,12 @@ function parsePromptResponse(raw: string | null): unknown {
   try {
     return JSON.parse(raw)
   } catch {
-    return null
+    return raw
   }
 }
 
 function responseLooksAffirmative(response: unknown): boolean {
+  if (typeof response === 'boolean') return response
   if (typeof response !== 'string') return false
   return /^(yes|y|confirm|confirmed|approve|approved|restart|ok|true)$/i.test(response.trim())
 }
@@ -56,7 +57,6 @@ async function hasRecentRestartConfirmation(ctx: { agentId: string; taskId?: str
           eq(humanPrompts.promptType, 'confirm'),
         ))
         .orderBy(desc(humanPrompts.respondedAt))
-        .limit(5)
         .all()
 
   return rows.some((prompt) => {

--- a/src/server/tools/platform-tools.ts
+++ b/src/server/tools/platform-tools.ts
@@ -2,12 +2,71 @@ import { readFileSync, writeFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
 import { tool } from '@/server/tools/tool-helper'
 import { z } from 'zod'
+import { eq, and, desc } from 'drizzle-orm'
 import { config } from '@/server/config'
 import { logStore } from '@/server/services/log-store'
 import { createLogger } from '@/server/logger'
 import type { ToolRegistration } from '@/server/tools/types'
 
 const log = createLogger('tools:platform')
+
+const RESTART_CONFIRMATION_TTL_MS = 10 * 60 * 1000
+
+function parsePromptResponse(raw: string | null): unknown {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+function responseLooksAffirmative(response: unknown): boolean {
+  if (typeof response !== 'string') return false
+  return /^(yes|y|confirm|confirmed|approve|approved|restart|ok|true)$/i.test(response.trim())
+}
+
+function textMentionsRestart(...parts: Array<string | null | undefined>): boolean {
+  const text = parts.filter(Boolean).join(' ').toLowerCase()
+  return /\b(restart|reboot)\b/.test(text)
+}
+
+async function hasRecentRestartConfirmation(ctx: { agentId: string; taskId?: string }, promptId?: string): Promise<boolean> {
+  const { db } = await import('@/server/db/index')
+  const { humanPrompts } = await import('@/server/db/schema')
+  const cutoff = new Date(Date.now() - RESTART_CONFIRMATION_TTL_MS)
+
+  const rows = promptId
+    ? await db
+        .select()
+        .from(humanPrompts)
+        .where(and(
+          eq(humanPrompts.id, promptId),
+          eq(humanPrompts.agentId, ctx.agentId),
+          eq(humanPrompts.status, 'answered'),
+          eq(humanPrompts.promptType, 'confirm'),
+        ))
+        .all()
+    : await db
+        .select()
+        .from(humanPrompts)
+        .where(and(
+          eq(humanPrompts.agentId, ctx.agentId),
+          eq(humanPrompts.status, 'answered'),
+          eq(humanPrompts.promptType, 'confirm'),
+        ))
+        .orderBy(desc(humanPrompts.respondedAt))
+        .limit(5)
+        .all()
+
+  return rows.some((prompt) => {
+    if ((prompt.taskId ?? undefined) !== (ctx.taskId ?? undefined)) return false
+    const respondedAt = prompt.respondedAt ? new Date(prompt.respondedAt as unknown as number | Date) : null
+    if (!respondedAt || respondedAt.getTime() < cutoff.getTime()) return false
+    if (!responseLooksAffirmative(parsePromptResponse(prompt.response))) return false
+    return textMentionsRestart(prompt.question, prompt.description)
+  })
+}
 
 /** Keys that are safe to expose via get_platform_config. Sensitive keys are redacted. */
 const SENSITIVE_KEYS = new Set([
@@ -514,16 +573,30 @@ export const restartPlatformTool: ToolRegistration = {
   create: (ctx) =>
     tool({
       description:
-        'Trigger a graceful restart of Hivekeep. Always use prompt_human() for user confirmation first.',
+        'Trigger a graceful restart of Hivekeep. Requires a recent answered prompt_human(confirm) that explicitly mentions restarting Hivekeep/the platform; an LLM-supplied boolean alone is not sufficient.',
       inputSchema: z.object({
         reason: z.string(),
         confirmed: z.boolean().describe('Must be true after explicit user confirmation via prompt_human()'),
+        prompt_id: z.string().optional().describe('Optional prompt_human confirmation promptId. If omitted, the most recent answered restart confirmation for this Agent is checked.'),
       }),
-      execute: async ({ reason, confirmed }) => {
+      execute: async ({ reason, confirmed, prompt_id }) => {
         if (!confirmed) {
           return {
             success: false,
-            error: 'Restart not confirmed. Use prompt_human() to get explicit user confirmation before restarting.',
+            error: 'Restart not confirmed. Use prompt_human(confirm) to get explicit user confirmation before restarting.',
+          }
+        }
+
+        let confirmedByPrompt = false
+        try {
+          confirmedByPrompt = await hasRecentRestartConfirmation(ctx, prompt_id)
+        } catch (err) {
+          log.warn({ agentId: ctx.agentId, err }, 'Failed to verify restart confirmation; denying restart')
+        }
+        if (!confirmedByPrompt) {
+          return {
+            success: false,
+            error: 'Restart requires a recent answered prompt_human(confirm) that explicitly mentions restarting Hivekeep/the platform. The LLM-supplied confirmed=true argument is not sufficient.',
           }
         }
 

--- a/src/server/tools/shell-tools.test.ts
+++ b/src/server/tools/shell-tools.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, mock, afterEach, beforeAll, afterAll } from 'bun:test'
-import { mkdirSync, rmSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync } from 'fs'
 import { fullMockConfig } from '../../test-helpers'
 import type { ToolRegistration } from '@/server/tools/types'
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const WORKSPACE_BASE = '/tmp/test-workspace-shell'
-
+const TMP_DIR = realpathSync('/tmp')
+const WORKSPACE_BASE = `${TMP_DIR}/test-workspace-shell`
 mock.module('@/server/config', () => ({
   config: {
     ...fullMockConfig,
@@ -97,7 +97,7 @@ describe('runShellTool', () => {
     it('uses custom cwd when provided', async () => {
       const result = await execute({ command: 'pwd', cwd: '/tmp' })
       expect(result.success).toBe(true)
-      expect(result.output).toBe('/tmp')
+      expect(result.output).toBe(TMP_DIR)
     })
 
     it('sets HIVEKEEP_KIN_ID environment variable', async () => {


### PR DESCRIPTION
## Summary

- Harden Codex/OAuth runtime behavior from the previously prepared broad branch, including macOS/Linux HOME-path handling and Codex model-cache fallback behavior.
- Harden restart/update flow and restart gating so platform restart controls are safer and better scoped.
- Normalize pending tool preview arguments so UI tool previews render more reliably while calls are in progress.
- Include related runtime/UI cleanup from the split bugfix branch, separated from the provider-expansion PR.

## Validation

Previously passed before this split PR branch was prepared:

- Provider-targeted tests and OpenRouter LLM tests passed during the broad branch validation.
- bun run typecheck — PASS.
- bun run build — PASS (existing Vite chunk-size warnings only).
- git diff --check — PASS.
- Full bun run test passed during final PR-prep before the broad work was split.

Additional lightweight verification during fork PR creation:

- Confirmed branch pr/runtime-ui-bugfixes is at ba5353ce6c219379176246cf855ef1df37bb4e0d.
- Confirmed push to kdegeek/hivekeep succeeded and branch tracks fork/pr/runtime-ui-bugfixes.
- Confirmed git diff --check against upstream main exits successfully for this branch.
