### PR TITLE
fix(ui): normalize pending tool-call previews + pending renderer states (split 1 of #27)

### DIFF
--- a/src/client/components/chat/InlineToolCall.test.ts
+++ b/src/client/components/chat/InlineToolCall.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { normalizeToolCallArgs } from './InlineToolCall'
+
+describe('normalizeToolCallArgs', () => {
+  test('normalizes missing pending tool-call args to an empty object', () => {
+    expect(normalizeToolCallArgs(undefined)).toEqual({})
+    expect(normalizeToolCallArgs(null)).toEqual({})
+  })
+
+  test('preserves provided args objects', () => {
+    const args = { value: 42 }
+    expect(normalizeToolCallArgs(args)).toBe(args)
+  })
+})

--- a/src/client/components/chat/InlineToolCall.tsx
+++ b/src/client/components/chat/InlineToolCall.tsx
@@ -32,6 +32,10 @@ interface InlineToolCallProps {
   toolCall: ToolCallViewItem
 }
 
+export function normalizeToolCallArgs(args: unknown): Record<string, unknown> {
+  return (args ?? {}) as Record<string, unknown>
+}
+
 /** Compact collapsible inline tool call shown within the Agent's message flow. */
 export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineToolCallProps) {
   const { t } = useTranslation()
@@ -54,7 +58,8 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
     ? toolCall.name.slice('custom_'.length)
     : null
   const previewFn = getPreviewRenderer(toolCall.name)
-  const preview = previewFn?.({ toolName: toolCall.name, args: toolCall.args as Record<string, unknown>, status: toolCall.status })
+  const args = normalizeToolCallArgs(toolCall.args)
+  const preview = previewFn?.({ toolName: toolCall.name, args, status: toolCall.status })
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -83,7 +88,7 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
             {CustomRenderer ? (
               <CustomRenderer
                 toolName={toolCall.name}
-                args={toolCall.args as Record<string, unknown>}
+                args={args}
                 result={toolCall.result}
                 status={toolCall.status}
               />
@@ -91,12 +96,12 @@ export const InlineToolCall = memo(function InlineToolCall({ toolCall }: InlineT
               <CustomToolRenderer
                 slug={customSlug}
                 result={toolCall.result}
-                args={toolCall.args}
+                args={args}
               />
             ) : (
               <>
                 <JsonViewer
-                  data={toolCall.args}
+                  data={args}
                   label={t('tools.viewer.input')}
                   maxHeight="max-h-40"
                 />

--- a/src/client/components/chat/ToolCallItem.tsx
+++ b/src/client/components/chat/ToolCallItem.tsx
@@ -57,7 +57,8 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
   const customSlug = isCustomTool ? toolCall.name.slice('custom_'.length) : null
   const humanName = customName ?? t(`tools.names.${toolCall.name}`, { defaultValue: toolCall.name })
   const previewFn = getPreviewRenderer(toolCall.name)
-  const preview = previewFn?.({ toolName: toolCall.name, args: toolCall.args as Record<string, unknown>, status: toolCall.status })
+  const args = (toolCall.args ?? {}) as Record<string, unknown>
+  const preview = previewFn?.({ toolName: toolCall.name, args, status: toolCall.status })
   const timeStr = new Date(toolCall.timestamp).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
@@ -92,7 +93,7 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
             {CustomRenderer ? (
               <CustomRenderer
                 toolName={toolCall.name}
-                args={toolCall.args as Record<string, unknown>}
+                args={args}
                 result={toolCall.result}
                 status={toolCall.status}
               />
@@ -105,7 +106,7 @@ export const ToolCallItem = memo(function ToolCallItem({ toolCall }: ToolCallIte
             ) : (
               <>
                 <JsonViewer
-                  data={toolCall.args}
+                  data={args}
                   label={t('tools.viewer.input')}
                   maxHeight="max-h-40"
                 />

--- a/src/client/components/chat/renderers/FileEditRenderer.tsx
+++ b/src/client/components/chat/renderers/FileEditRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, FilePen, FileWarning } from 'lucide-react'
+import { ChevronDown, ChevronRight, FilePen, FileWarning, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -10,16 +10,18 @@ export function FileEditRenderer({ args, result, status }: ToolResultRendererPro
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const applied = res?.applied === true
-  const oldText = typeof res?.oldText === 'string' ? res.oldText : typeof args.oldText === 'string' ? args.oldText : null
-  const newText = typeof res?.newText === 'string' ? res.newText : typeof args.newText === 'string' ? args.newText : null
+  const oldText = typeof res?.oldText === 'string' ? res.oldText : typeof args?.oldText === 'string' ? args.oldText : null
+  const newText = typeof res?.newText === 'string' ? res.newText : typeof args?.newText === 'string' ? args.newText : null
   const language = typeof res?.language === 'string' ? res.language : null
   const editLine = typeof res?.editLine === 'number' ? res.editLine : null
   const error = typeof res?.error === 'string' ? res.error : null
 
-  if (!success) {
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -29,6 +31,21 @@ export function FileEditRenderer({ args, result, status }: ToolResultRendererPro
             <span className="ml-auto shrink-0 text-[10px] text-red-400">{t('tools.renderers.failed')}</span>
           </div>
           <div className="px-3 py-2 text-red-300 break-words">{error ?? t('tools.renderers.editFailed')}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{filePath ?? t('tools.renderers.file')}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.editingFile', { defaultValue: 'Preparing edit preview…' })}</div>
         </div>
       </div>
     )

--- a/src/client/components/chat/renderers/FileReadRenderer.tsx
+++ b/src/client/components/chat/renderers/FileReadRenderer.tsx
@@ -10,7 +10,7 @@ export function FileReadRenderer({ args, result, status }: ToolResultRendererPro
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof args.path === 'string' ? args.path : null
+  const filePath = typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const content = typeof res?.content === 'string' ? res.content : null
   const language = typeof res?.language === 'string' ? res.language : null

--- a/src/client/components/chat/renderers/FileWriteRenderer.tsx
+++ b/src/client/components/chat/renderers/FileWriteRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, FilePlus, FilePen } from 'lucide-react'
+import { ChevronDown, ChevronRight, FilePlus, FilePen, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -47,17 +47,19 @@ export function FileWriteRenderer({ args, result, status }: ToolResultRendererPr
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const created = res?.created === true
   const bytesWritten = typeof res?.bytesWritten === 'number' ? res.bytesWritten : null
   const linesWritten = typeof res?.linesWritten === 'number' ? res.linesWritten : null
   const language = typeof res?.language === 'string' ? res.language : null
   const previousContent = typeof res?.previousContent === 'string' ? res.previousContent : null
-  const content = typeof args.content === 'string' ? args.content : null
+  const content = typeof args?.content === 'string' ? args.content : null
   const error = typeof res?.error === 'string' ? res.error : null
 
-  if (!success) {
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -67,6 +69,21 @@ export function FileWriteRenderer({ args, result, status }: ToolResultRendererPr
             <span className="ml-auto shrink-0 text-[10px] text-red-400">{t('tools.renderers.error')}</span>
           </div>
           <div className="px-3 py-2 text-red-300 break-words">{error ?? t('tools.renderers.writeFailed')}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{filePath ?? t('tools.renderers.file')}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.writingFile', { defaultValue: 'Preparing write preview…' })}</div>
         </div>
       </div>
     )

--- a/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
+++ b/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, Folder, FolderOpen, FileText, FolderSearch } from 'lucide-react'
+import { ChevronDown, ChevronRight, Folder, FolderOpen, FileText, FolderSearch, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -79,7 +79,12 @@ export function ListDirectoryRenderer({ args, result, status }: ToolResultRender
   const entries = Array.isArray(res?.entries) ? (res.entries as DirEntry[]) : null
   const error = typeof res?.error === 'string' ? res.error : null
 
-  if (!success) {
+  // Only a real error or a completed-but-unsuccessful result is a failure; an
+  // as-yet-unresolved call (no result) is pending, not failed. Mirrors
+  // FileEditRenderer / FileWriteRenderer.
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -89,6 +94,21 @@ export function ListDirectoryRenderer({ args, result, status }: ToolResultRender
             <span className="ml-auto shrink-0 text-[10px] text-red-400">{t('tools.renderers.error')}</span>
           </div>
           <div className="px-3 py-2 text-red-300 break-words">{error ?? t('tools.renderers.failedToListDirectory')}</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{dirPath}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.listingDirectory', { defaultValue: 'Preparing directory listing…' })}</div>
         </div>
       </div>
     )

--- a/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
+++ b/src/client/components/chat/renderers/ListDirectoryRenderer.tsx
@@ -75,7 +75,7 @@ export function ListDirectoryRenderer({ args, result, status }: ToolResultRender
 
   const res = result as Record<string, unknown> | null | undefined
   const success = res?.success === true
-  const dirPath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : '.'
+  const dirPath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : '.'
   const entries = Array.isArray(res?.entries) ? (res.entries as DirEntry[]) : null
   const error = typeof res?.error === 'string' ? res.error : null
 

--- a/src/client/components/chat/renderers/MultiEditRenderer.tsx
+++ b/src/client/components/chat/renderers/MultiEditRenderer.tsx
@@ -21,14 +21,14 @@ export function MultiEditRenderer({ args, result, status }: ToolResultRendererPr
   const [showRaw, setShowRaw] = useState(false)
 
   const res = result as Record<string, unknown> | null | undefined
-  const filePath = typeof res?.path === 'string' ? res.path : typeof args.path === 'string' ? args.path : null
+  const filePath = typeof res?.path === 'string' ? res.path : typeof args?.path === 'string' ? args.path : null
   const success = res?.success === true
   const language = typeof res?.language === 'string' ? res.language : null
   const editsApplied = typeof res?.editsApplied === 'number' ? res.editsApplied : null
   const error = typeof res?.error === 'string' ? res.error : null
   const failedEditIndex = typeof res?.failedEditIndex === 'number' ? res.failedEditIndex : null
 
-  const edits = Array.isArray(args.edits) ? (args.edits as EditPair[]) : null
+  const edits = Array.isArray(args?.edits) ? (args.edits as EditPair[]) : null
 
   if (!success) {
     return (

--- a/src/client/components/chat/renderers/MultiEditRenderer.tsx
+++ b/src/client/components/chat/renderers/MultiEditRenderer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '@/client/lib/utils'
-import { ChevronDown, ChevronRight, FilePen, FileWarning } from 'lucide-react'
+import { ChevronDown, ChevronRight, FilePen, FileWarning, Loader2 } from 'lucide-react'
 import { JsonViewer } from '@/client/components/common/JsonViewer'
 import type { ToolResultRendererProps } from '@/client/lib/tool-renderers'
 
@@ -30,7 +30,12 @@ export function MultiEditRenderer({ args, result, status }: ToolResultRendererPr
 
   const edits = Array.isArray(args?.edits) ? (args.edits as EditPair[]) : null
 
-  if (!success) {
+  // Only a real error or a completed-but-unsuccessful result is a failure; an
+  // as-yet-unresolved call (no result) is pending, not failed. Mirrors
+  // FileEditRenderer / FileWriteRenderer.
+  const failed = status === 'error' || error !== null || (result !== undefined && !success)
+
+  if (failed) {
     return (
       <div className="space-y-2">
         <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
@@ -45,6 +50,21 @@ export function MultiEditRenderer({ args, result, status }: ToolResultRendererPr
             )}
             {error ?? t('tools.renderers.editFailed')}
           </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!success) {
+    return (
+      <div className="space-y-2">
+        <div className="rounded-md bg-zinc-950 text-zinc-100 text-xs font-mono overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-zinc-900 border-b border-zinc-800">
+            <Loader2 className="size-3 text-blue-400 shrink-0 animate-spin" />
+            <span className="min-w-0 truncate text-zinc-400 text-[10px]">{filePath ?? t('tools.renderers.file')}</span>
+            <span className="ml-auto shrink-0 text-[10px] text-blue-400">{t('tools.status.pending', { defaultValue: 'Pending' })}</span>
+          </div>
+          <div className="px-3 py-2 text-zinc-400 break-words">{t('tools.renderers.editingFile', { defaultValue: 'Preparing edit preview…' })}</div>
         </div>
       </div>
     )

--- a/src/client/lib/tool-preview-renderers.test.ts
+++ b/src/client/lib/tool-preview-renderers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { getPreviewRenderer } from './tool-registry'
+import { FileEditRenderer } from '@/client/components/chat/renderers/FileEditRenderer'
+import { FileReadRenderer } from '@/client/components/chat/renderers/FileReadRenderer'
+import { FileWriteRenderer } from '@/client/components/chat/renderers/FileWriteRenderer'
+import './tool-preview-renderers'
+
+describe('tool preview renderers', () => {
+  const fileToolNames = [
+    'read_file',
+    'write_file',
+    'edit_file',
+    'multi_edit',
+    'list_directory',
+    'write_mini_app_file',
+    'read_mini_app_file',
+    'delete_mini_app_file',
+  ]
+
+  it('does not throw while file tool args are still pending', () => {
+    for (const toolName of fileToolNames) {
+      const renderer = getPreviewRenderer(toolName)
+      expect(renderer, toolName).toBeDefined()
+      expect(() => renderer?.({ toolName, args: undefined as unknown as Record<string, unknown>, status: 'pending' })).not.toThrow()
+    }
+  })
+
+  it('keeps pending built-in file renderers out of failure state', () => {
+    const pendingProps = { args: { path: 'src/app.ts', content: 'hello', oldText: 'a', newText: 'b' }, result: undefined, status: 'pending' as const }
+
+    for (const [toolName, Renderer] of [
+      ['read_file', FileReadRenderer],
+      ['write_file', FileWriteRenderer],
+      ['edit_file', FileEditRenderer],
+    ] as const) {
+      const html = renderToStaticMarkup(createElement(Renderer, { toolName, ...pendingProps }))
+      expect(html.toLowerCase()).not.toContain('failed')
+      expect(html.toLowerCase()).not.toContain('error')
+    }
+  })
+
+  it('does not throw while non-file tool args are still pending', () => {
+    const pendingToolNames = [
+      'spawn_self',
+      'spawn_agent',
+      'task_todos',
+      'run_shell',
+      'add_mcp_server',
+    ]
+
+    for (const toolName of pendingToolNames) {
+      const renderer = getPreviewRenderer(toolName)
+      expect(renderer, toolName).toBeDefined()
+      expect(() => renderer?.({ toolName, args: undefined as unknown as Record<string, unknown>, status: 'pending' })).not.toThrow()
+    }
+  })
+
+  it('keeps completed file previews when args exist', () => {
+    expect(getPreviewRenderer('read_file')?.({ toolName: 'read_file', args: { path: 'src/app.ts' }, status: 'success' })).toBe('src/app.ts')
+    expect(getPreviewRenderer('multi_edit')?.({
+      toolName: 'multi_edit',
+      args: { path: 'src/app.ts', edits: [{ oldText: 'a', newText: 'b' }, { oldText: 'c', newText: 'd' }] },
+      status: 'success',
+    })).toBe('src/app.ts (2 edits)')
+    expect(getPreviewRenderer('list_directory')?.({ toolName: 'list_directory', args: {}, status: 'pending' })).toBe('.')
+  })
+
+  it('keeps completed previews for title, todo, and command args', () => {
+    expect(getPreviewRenderer('spawn_self')?.({ toolName: 'spawn_self', args: { title: 'Investigate flaky renderer' }, status: 'success' })).toBe('Investigate flaky renderer')
+    expect(getPreviewRenderer('task_todos')?.({
+      toolName: 'task_todos',
+      args: { todos: [{ id: 'a', subject: 'Inspect', status: 'completed' }, { id: 'b', subject: 'Fix', status: 'pending' }] },
+      status: 'success',
+    })).toBe('1/2')
+    expect(getPreviewRenderer('run_shell')?.({ toolName: 'run_shell', args: { command: 'bun run typecheck' }, status: 'success' })).toBe('bun run typecheck')
+    expect(getPreviewRenderer('add_mcp_server')?.({ toolName: 'add_mcp_server', args: { name: 'filesystem', command: 'npx -y @modelcontextprotocol/server-filesystem' }, status: 'success' })).toBe('filesystem (npx -y @modelco…)')
+  })
+})

--- a/src/client/lib/tool-preview-renderers.ts
+++ b/src/client/lib/tool-preview-renderers.ts
@@ -9,44 +9,59 @@ function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + '…' : s
 }
 
+function getArg(args: Record<string, unknown> | null | undefined, key: string): unknown {
+  return args?.[key]
+}
+
+function getStringArg(args: Record<string, unknown> | null | undefined, key: string): string | undefined {
+  const value = getArg(args, key)
+  return typeof value === 'string' ? value : undefined
+}
+
+function getPathArg(args: Record<string, unknown> | null | undefined): string | null {
+  return getStringArg(args, 'path') || null
+}
+
 // --- Shell / system ---
 
 registerPreviewRenderer('run_shell', ({ args }) => {
-  const cmd = args.command as string | undefined
+  const cmd = getStringArg(args, 'command')
   return cmd ? truncate(cmd, 60) : null
 })
 
 registerPreviewRenderer('execute_sql', ({ args }) => {
-  return (args.sql as string) ? truncate(args.sql as string, 50) : null
+  const sql = getStringArg(args, 'sql')
+  return sql ? truncate(sql, 50) : null
 })
 
 // --- File operations ---
 
 registerPreviewRenderer('read_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('write_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('edit_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('multi_edit', ({ args }) => {
-  const path = args.path as string
-  const count = Array.isArray(args.edits) ? args.edits.length : undefined
+  const path = getPathArg(args)
+  const edits = getArg(args, 'edits')
+  const count = Array.isArray(edits) ? edits.length : undefined
   return path ? `${path}${count ? ` (${count} edits)` : ''}` : null
 })
 
 registerPreviewRenderer('list_directory', ({ args }) => {
-  return (args.path as string) || '.'
+  return getPathArg(args) || '.'
 })
 
 registerPreviewRenderer('grep', ({ args }) => {
-  const pattern = args.pattern as string
-  const glob = args.glob as string | undefined
+  const pattern = getStringArg(args, 'pattern')
+  const glob = getStringArg(args, 'glob')
   return pattern ? `"${truncate(pattern, 30)}"${glob ? ` in ${glob}` : ''}` : null
 })
 
@@ -312,7 +327,7 @@ registerPreviewRenderer('wake_me_in', ({ args }) => {
 // --- Mini apps ---
 
 registerPreviewRenderer('write_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 registerPreviewRenderer('create_mini_app', ({ args }) => {
@@ -490,7 +505,7 @@ registerPreviewRenderer('uninstall_plugin', ({ args }) => {
 // --- Mini app file read ---
 
 registerPreviewRenderer('read_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 // --- Secret retrieval ---
@@ -616,7 +631,7 @@ registerPreviewRenderer('update_memory', ({ args }) => {
 // --- Mini app file deletion ---
 
 registerPreviewRenderer('delete_mini_app_file', ({ args }) => {
-  return (args.path as string) || null
+  return getPathArg(args)
 })
 
 // --- Email ---

--- a/src/client/lib/tool-registry.ts
+++ b/src/client/lib/tool-registry.ts
@@ -37,7 +37,11 @@ export function getRenderer(toolName: string): ComponentType<ToolResultRendererP
 const previewRegistry = new Map<string, ToolPreviewFn>()
 
 export function registerPreviewRenderer(toolName: string, fn: ToolPreviewFn) {
-  previewRegistry.set(toolName, fn)
+  // chat:tool-call-start can render a preview before streamed tool args have
+  // arrived. Normalize here so every current/future preview renderer can read
+  // fields like args.title / args.todos / args.command without crashing while
+  // the call is still pending.
+  previewRegistry.set(toolName, (props) => fn({ ...props, args: props.args ?? {} }))
 }
 
 export function getPreviewRenderer(toolName: string): ToolPreviewFn | undefined {

--- a/src/client/locales/de.json
+++ b/src/client/locales/de.json
@@ -3037,7 +3037,12 @@
       "thought": "Gedanke",
       "todosTitle": "Plan",
       "todosProgress": "{{completed}}/{{total}} erledigt",
-      "todosEmpty": "Keine Schritte"
+      "todosEmpty": "Keine Schritte",
+      "editingFile": "Bearbeitungsvorschau wird vorbereitet…",
+      "writingFile": "Schreibvorschau wird vorbereitet…"
+    },
+    "status": {
+      "pending": "Ausstehend"
     }
   },
   "invite": {

--- a/src/client/locales/de.json
+++ b/src/client/locales/de.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} erledigt",
       "todosEmpty": "Keine Schritte",
       "editingFile": "Bearbeitungsvorschau wird vorbereitet…",
-      "writingFile": "Schreibvorschau wird vorbereitet…"
+      "writingFile": "Schreibvorschau wird vorbereitet…",
+      "listingDirectory": "Verzeichnisauflistung wird vorbereitet…"
     },
     "status": {
       "pending": "Ausstehend"

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} done",
       "todosEmpty": "No steps",
       "editingFile": "Preparing edit preview…",
-      "writingFile": "Preparing write preview…"
+      "writingFile": "Preparing write preview…",
+      "listingDirectory": "Preparing directory listing…"
     },
     "status": {
       "pending": "Pending"

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -3037,7 +3037,12 @@
       "thought": "Thought",
       "todosTitle": "Plan",
       "todosProgress": "{{completed}}/{{total}} done",
-      "todosEmpty": "No steps"
+      "todosEmpty": "No steps",
+      "editingFile": "Preparing edit preview…",
+      "writingFile": "Preparing write preview…"
+    },
+    "status": {
+      "pending": "Pending"
     }
   },
   "invite": {

--- a/src/client/locales/es.json
+++ b/src/client/locales/es.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} hechas",
       "todosEmpty": "Sin pasos",
       "editingFile": "Preparando la vista previa de la edición…",
-      "writingFile": "Preparando la vista previa de escritura…"
+      "writingFile": "Preparando la vista previa de escritura…",
+      "listingDirectory": "Preparando el listado del directorio…"
     },
     "status": {
       "pending": "Pendiente"

--- a/src/client/locales/es.json
+++ b/src/client/locales/es.json
@@ -3037,7 +3037,12 @@
       "thought": "Pensamiento",
       "todosTitle": "Plan",
       "todosProgress": "{{completed}}/{{total}} hechas",
-      "todosEmpty": "Sin pasos"
+      "todosEmpty": "Sin pasos",
+      "editingFile": "Preparando la vista previa de la edición…",
+      "writingFile": "Preparando la vista previa de escritura…"
+    },
+    "status": {
+      "pending": "Pendiente"
     }
   },
   "invite": {

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} terminé",
       "todosEmpty": "Aucune étape",
       "editingFile": "Préparation de l'aperçu de modification…",
-      "writingFile": "Préparation de l'aperçu d'écriture…"
+      "writingFile": "Préparation de l'aperçu d'écriture…",
+      "listingDirectory": "Préparation du listing du répertoire…"
     },
     "status": {
       "pending": "En attente"

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -3037,7 +3037,12 @@
       "thought": "Réflexion",
       "todosTitle": "Plan",
       "todosProgress": "{{completed}}/{{total}} terminé",
-      "todosEmpty": "Aucune étape"
+      "todosEmpty": "Aucune étape",
+      "editingFile": "Préparation de l'aperçu de modification…",
+      "writingFile": "Préparation de l'aperçu d'écriture…"
+    },
+    "status": {
+      "pending": "En attente"
     }
   },
   "invite": {

--- a/src/client/locales/it.json
+++ b/src/client/locales/it.json
@@ -3037,7 +3037,12 @@
       "thought": "Pensiero",
       "todosTitle": "Piano",
       "todosProgress": "{{completed}}/{{total}} fatti",
-      "todosEmpty": "Nessun passo"
+      "todosEmpty": "Nessun passo",
+      "editingFile": "Preparazione dell'anteprima di modifica…",
+      "writingFile": "Preparazione dell'anteprima di scrittura…"
+    },
+    "status": {
+      "pending": "In attesa"
     }
   },
   "invite": {

--- a/src/client/locales/it.json
+++ b/src/client/locales/it.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} fatti",
       "todosEmpty": "Nessun passo",
       "editingFile": "Preparazione dell'anteprima di modifica…",
-      "writingFile": "Preparazione dell'anteprima di scrittura…"
+      "writingFile": "Preparazione dell'anteprima di scrittura…",
+      "listingDirectory": "Preparazione dell'elenco della directory…"
     },
     "status": {
       "pending": "In attesa"

--- a/src/client/locales/ja.json
+++ b/src/client/locales/ja.json
@@ -3037,7 +3037,12 @@
       "thought": "思考",
       "todosTitle": "プラン",
       "todosProgress": "{{completed}}/{{total}}完了",
-      "todosEmpty": "ステップなし"
+      "todosEmpty": "ステップなし",
+      "editingFile": "編集プレビューを準備中…",
+      "writingFile": "書き込みプレビューを準備中…"
+    },
+    "status": {
+      "pending": "保留中"
     }
   },
   "invite": {

--- a/src/client/locales/ja.json
+++ b/src/client/locales/ja.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}}完了",
       "todosEmpty": "ステップなし",
       "editingFile": "編集プレビューを準備中…",
-      "writingFile": "書き込みプレビューを準備中…"
+      "writingFile": "書き込みプレビューを準備中…",
+      "listingDirectory": "ディレクトリ一覧を準備中…"
     },
     "status": {
       "pending": "保留中"

--- a/src/client/locales/pl.json
+++ b/src/client/locales/pl.json
@@ -3057,7 +3057,8 @@
       "todosProgress": "ukończono {{completed}}/{{total}}",
       "todosEmpty": "Brak kroków",
       "editingFile": "Przygotowywanie podglądu edycji…",
-      "writingFile": "Przygotowywanie podglądu zapisu…"
+      "writingFile": "Przygotowywanie podglądu zapisu…",
+      "listingDirectory": "Przygotowywanie listy katalogu…"
     },
     "status": {
       "pending": "Oczekuje"

--- a/src/client/locales/pl.json
+++ b/src/client/locales/pl.json
@@ -3055,7 +3055,12 @@
       "thought": "Myśl",
       "todosTitle": "Plan",
       "todosProgress": "ukończono {{completed}}/{{total}}",
-      "todosEmpty": "Brak kroków"
+      "todosEmpty": "Brak kroków",
+      "editingFile": "Przygotowywanie podglądu edycji…",
+      "writingFile": "Przygotowywanie podglądu zapisu…"
+    },
+    "status": {
+      "pending": "Oczekuje"
     }
   },
   "invite": {

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -3037,7 +3037,12 @@
       "thought": "Pensamento",
       "todosTitle": "Plano",
       "todosProgress": "{{completed}}/{{total}} concluídos",
-      "todosEmpty": "Nenhuma etapa"
+      "todosEmpty": "Nenhuma etapa",
+      "editingFile": "Preparando a prévia da edição…",
+      "writingFile": "Preparando a prévia da escrita…"
+    },
+    "status": {
+      "pending": "Pendente"
     }
   },
   "invite": {

--- a/src/client/locales/pt-BR.json
+++ b/src/client/locales/pt-BR.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} concluídos",
       "todosEmpty": "Nenhuma etapa",
       "editingFile": "Preparando a prévia da edição…",
-      "writingFile": "Preparando a prévia da escrita…"
+      "writingFile": "Preparando a prévia da escrita…",
+      "listingDirectory": "Preparando a listagem do diretório…"
     },
     "status": {
       "pending": "Pendente"

--- a/src/client/locales/ru.json
+++ b/src/client/locales/ru.json
@@ -3061,7 +3061,12 @@
       "thought": "Мысль",
       "todosTitle": "План",
       "todosProgress": "Готово: {{completed}}/{{total}}",
-      "todosEmpty": "Шагов нет"
+      "todosEmpty": "Шагов нет",
+      "editingFile": "Подготовка предпросмотра изменений…",
+      "writingFile": "Подготовка предпросмотра записи…"
+    },
+    "status": {
+      "pending": "Ожидание"
     }
   },
   "invite": {

--- a/src/client/locales/ru.json
+++ b/src/client/locales/ru.json
@@ -3063,7 +3063,8 @@
       "todosProgress": "Готово: {{completed}}/{{total}}",
       "todosEmpty": "Шагов нет",
       "editingFile": "Подготовка предпросмотра изменений…",
-      "writingFile": "Подготовка предпросмотра записи…"
+      "writingFile": "Подготовка предпросмотра записи…",
+      "listingDirectory": "Подготовка списка каталога…"
     },
     "status": {
       "pending": "Ожидание"

--- a/src/client/locales/zh-CN.json
+++ b/src/client/locales/zh-CN.json
@@ -3039,7 +3039,8 @@
       "todosProgress": "{{completed}}/{{total}} 已完成",
       "todosEmpty": "没有步骤",
       "editingFile": "正在准备编辑预览…",
-      "writingFile": "正在准备写入预览…"
+      "writingFile": "正在准备写入预览…",
+      "listingDirectory": "正在准备目录列表…"
     },
     "status": {
       "pending": "待处理"

--- a/src/client/locales/zh-CN.json
+++ b/src/client/locales/zh-CN.json
@@ -3037,7 +3037,12 @@
       "thought": "思考",
       "todosTitle": "计划",
       "todosProgress": "{{completed}}/{{total}} 已完成",
-      "todosEmpty": "没有步骤"
+      "todosEmpty": "没有步骤",
+      "editingFile": "正在准备编辑预览…",
+      "writingFile": "正在准备写入预览…"
+    },
+    "status": {
+      "pending": "待处理"
     }
   },
   "invite": {

--- a/src/server/tools/shell-tools.test.ts
+++ b/src/server/tools/shell-tools.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, mock, afterEach, beforeAll, afterAll } from 'bun:test'
-import { mkdirSync, rmSync } from 'fs'
+import { mkdirSync, realpathSync, rmSync } from 'fs'
 import { fullMockConfig } from '../../test-helpers'
 import type { ToolRegistration } from '@/server/tools/types'
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-const WORKSPACE_BASE = '/tmp/test-workspace-shell'
-
+const TMP_DIR = realpathSync('/tmp')
+const WORKSPACE_BASE = `${TMP_DIR}/test-workspace-shell`
 mock.module('@/server/config', () => ({
   config: {
     ...fullMockConfig,
@@ -97,7 +97,7 @@ describe('runShellTool', () => {
     it('uses custom cwd when provided', async () => {
       const result = await execute({ command: 'pwd', cwd: '/tmp' })
       expect(result.success).toBe(true)
-      expect(result.output).toBe('/tmp')
+      expect(result.output).toBe(TMP_DIR)
     })
 
     it('sets HIVEKEEP_KIN_ID environment variable', async () => {


### PR DESCRIPTION
## Summary

First split out of #27 (the runtime/UI hardening branch), per @MarlBurroW's suggested breakdown — the self-contained, easily-mergeable UI slice, rebased on current `main`.

- **Normalize pending tool-call preview args.** `chat:tool-call-start` renders a preview before streamed tool args arrive, so a preview renderer reading `args.path` / `args.command` / `args.title` could crash on a still-pending call. Args are now normalized to `{}` centrally in `registerPreviewRenderer` (and `normalizeToolCallArgs`), with safe `getStringArg` / `getPathArg` accessors in the preview renderers.
- **Pending renderer states for file-op result renderers.** FileEdit and FileWrite render an explicit spinner + "pending" state while their args stream, instead of flashing their result/failure UI.
- **Add the previously-missing i18n keys** these states use — `tools.status.pending`, `tools.renderers.editingFile`, `tools.renderers.writingFile` — to `en.json` **and all nine other locales**, so the English `defaultValue` no longer leaks into every language.

### Two additions beyond the original branch (both in-theme)

- **MultiEdit and ListDirectory get the same pending handling.** Both previously rendered the red *failed* UI for an unresolved call (`success` is `false` while `result` is `undefined`). They now distinguish pending from failed exactly like FileEdit/FileWrite (`failed = status === 'error' || error !== null || (result !== undefined && !success)`). One caught by a CodeRabbit pass (MultiEdit), the other found alongside it (ListDirectory).
- **A 4th locale key**, `tools.renderers.listingDirectory`, for the ListDirectory pending message (multi_edit reuses `editingFile`).

## Validation

- `bun run typecheck` — PASS
- `bun run test` — PASS (3985 tests)
- `bun run build` — PASS (pre-existing Vite chunk-size warnings only)
- `bun scripts/check-locales.ts` — PASS (all 10 locales, matching key paths, no em-dashes)
- `git diff --check` — PASS
- CodeRabbit review — 0 findings

The remaining pieces of #27 (crash-safe pre-insert/checkpoint, the multi-candidate auth/cache path resolution + `getRealHome` boot-crash fix, and the restart-gating / toolbox-grant design questions) will follow as separate PRs / discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
