### PR TITLE
fix(codex/oauth): resolve cache & credential paths under the real home on macOS (split 2 of #27)

### DIFF
--- a/src/server/llm/llm/_anthropic-oauth-auth.ts
+++ b/src/server/llm/llm/_anthropic-oauth-auth.ts
@@ -28,7 +28,8 @@
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { createHash, randomBytes, randomUUID } from 'crypto'
-import { isAbsolute, join, normalize } from 'path'
+import { join } from 'path'
+import { REAL_HOME, normalizeAbsoluteHome } from '@/server/llm/llm/_home-paths'
 import { createLogger } from '@/server/logger'
 import type { ProviderConfig } from '@/server/llm/core/types'
 import type { PkceClient } from '@/server/llm/llm/_oauth-pkce'
@@ -63,31 +64,6 @@ export const ANTHROPIC_PKCE_CLIENT: PkceClient = {
 // releases new versions to avoid being flagged as an outdated client.
 const CLAUDE_CODE_VERSION = '2.1.120'
 const BUFFER_MS = 5 * 60 * 1000 // refresh 5 min before expiry
-
-/**
- * Resolve the real user home directory.
- * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer the REAL_HOME or the home from /etc/passwd via the USER env var.
- */
-function getRealHome(): string {
-  // REAL_HOME is set by some snap environments
-  if (process.env.REAL_HOME) return process.env.REAL_HOME
-  // Fall back to HOME, but strip snap paths
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
-  if (snapMatch) return snapMatch[1]!
-  // Last resort: construct from USER
-  if (process.env.USER) return `/home/${process.env.USER}`
-  return home
-}
-
-const REAL_HOME = getRealHome()
-
-function normalizeAbsoluteHome(home: string | undefined): string | null {
-  if (!home) return null
-  const normalized = normalize(home)
-  return isAbsolute(normalized) ? normalized : null
-}
 
 // Credential filenames the Claude CLI may use, relative to a home directory.
 const CLAUDE_CREDENTIAL_RELPATHS: string[][] = [

--- a/src/server/llm/llm/_anthropic-oauth-auth.ts
+++ b/src/server/llm/llm/_anthropic-oauth-auth.ts
@@ -28,7 +28,7 @@
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { createHash, randomBytes, randomUUID } from 'crypto'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import { createLogger } from '@/server/logger'
 import type { ProviderConfig } from '@/server/llm/core/types'
 import type { PkceClient } from '@/server/llm/llm/_oauth-pkce'
@@ -83,11 +83,40 @@ function getRealHome(): string {
 
 const REAL_HOME = getRealHome()
 
-const CANDIDATE_PATHS = [
-  join(REAL_HOME, '.claude', '.credentials.json'),
-  join(REAL_HOME, '.claude.json'),
-  join(REAL_HOME, '.claude', 'credentials.json'),
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
+// Credential filenames the Claude CLI may use, relative to a home directory.
+const CLAUDE_CREDENTIAL_RELPATHS: string[][] = [
+  ['.claude', '.credentials.json'],
+  ['.claude.json'],
+  ['.claude', 'credentials.json'],
 ]
+
+// Search the plain env HOME first, then the snap-adjusted REAL_HOME. On macOS
+// and nonstandard homes REAL_HOME can resolve to the wrong place (e.g. getRealHome
+// builds /home/$USER while the real home is /Users/$USER), so the env HOME
+// candidate is what actually finds the credentials there.
+function claudeCredentialCandidates(): string[] {
+  const bases: string[] = []
+  for (const home of [process.env.HOME, REAL_HOME]) {
+    const base = normalizeAbsoluteHome(home)
+    if (base && !bases.includes(base)) bases.push(base)
+  }
+  const paths: string[] = []
+  for (const base of bases) {
+    for (const rel of CLAUDE_CREDENTIAL_RELPATHS) {
+      const p = join(base, ...rel)
+      if (!paths.includes(p)) paths.push(p)
+    }
+  }
+  return paths
+}
+
+const CANDIDATE_PATHS = claudeCredentialCandidates()
 
 // ---------------------------------------------------------------------------
 // Types

--- a/src/server/llm/llm/_codex-auth.ts
+++ b/src/server/llm/llm/_codex-auth.ts
@@ -11,7 +11,7 @@
  * against the user's ChatGPT subscription (Plus/Pro).
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import { createLogger } from '@/server/logger'
 import type { ProviderConfig } from '@/server/llm/core/types'
 import { decodeJwtClaims, type PkceClient, type PkceTokenResponse } from '@/server/llm/llm/_oauth-pkce'
@@ -72,9 +72,28 @@ function getRealHome(): string {
 
 const REAL_HOME = getRealHome()
 
-const CANDIDATE_PATHS = [
-  join(REAL_HOME, '.codex', 'auth.json'),
-]
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
+// Search the plain env HOME first, then the snap-adjusted REAL_HOME. On macOS
+// and nonstandard homes REAL_HOME can resolve to the wrong place (e.g. getRealHome
+// builds /home/$USER while the real home is /Users/$USER), so the env HOME
+// candidate is what actually finds the file there.
+function codexAuthCandidates(): string[] {
+  const paths: string[] = []
+  for (const home of [process.env.HOME, REAL_HOME]) {
+    const base = normalizeAbsoluteHome(home)
+    if (!base) continue
+    const p = join(base, '.codex', 'auth.json')
+    if (!paths.includes(p)) paths.push(p)
+  }
+  return paths
+}
+
+const CANDIDATE_PATHS = codexAuthCandidates()
 
 
 // ---------------------------------------------------------------------------

--- a/src/server/llm/llm/_codex-auth.ts
+++ b/src/server/llm/llm/_codex-auth.ts
@@ -11,7 +11,8 @@
  * against the user's ChatGPT subscription (Plus/Pro).
  */
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import { isAbsolute, join, normalize } from 'path'
+import { join } from 'path'
+import { REAL_HOME, normalizeAbsoluteHome } from '@/server/llm/llm/_home-paths'
 import { createLogger } from '@/server/logger'
 import type { ProviderConfig } from '@/server/llm/core/types'
 import { decodeJwtClaims, type PkceClient, type PkceTokenResponse } from '@/server/llm/llm/_oauth-pkce'
@@ -54,28 +55,6 @@ export function codexAccountIdFromTokens(tokens: PkceTokenResponse): Record<stri
   const auth = claims?.['https://api.openai.com/auth'] as { chatgpt_account_id?: string } | undefined
   const accountId = auth?.chatgpt_account_id
   return accountId ? { accountId } : undefined
-}
-
-/**
- * Resolve the real user home directory.
- * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
- * We prefer the REAL_HOME or the home from /etc/passwd via the USER env var.
- */
-function getRealHome(): string {
-  if (process.env.REAL_HOME) return process.env.REAL_HOME
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
-  if (snapMatch) return snapMatch[1]!
-  if (process.env.USER) return `/home/${process.env.USER}`
-  return home
-}
-
-const REAL_HOME = getRealHome()
-
-function normalizeAbsoluteHome(home: string | undefined): string | null {
-  if (!home) return null
-  const normalized = normalize(home)
-  return isAbsolute(normalized) ? normalized : null
 }
 
 // Search the plain env HOME first, then the snap-adjusted REAL_HOME. On macOS

--- a/src/server/llm/llm/_home-paths.ts
+++ b/src/server/llm/llm/_home-paths.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared home-directory resolution for the OAuth/CLI provider helpers.
+ *
+ * Underscore-prefixed so the provider registry's `import.meta.glob` skips it.
+ * Keeping this in one place avoids the three credential/cache path resolvers
+ * (openai-codex, _codex-auth, _anthropic-oauth-auth) drifting apart.
+ */
+import { isAbsolute, normalize } from 'path'
+
+/**
+ * Resolve the real user home directory.
+ * Bun installed via snap sets HOME to a sandboxed path (e.g. ~/snap/bun-js/87/).
+ * We prefer REAL_HOME, strip snap paths from HOME, and only construct
+ * /home/$USER as a last resort.
+ */
+function getRealHome(): string {
+  // REAL_HOME is set by some snap environments.
+  if (process.env.REAL_HOME) return process.env.REAL_HOME
+  // Fall back to HOME, but strip snap paths.
+  const home = process.env.HOME ?? ''
+  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
+  if (snapMatch) return snapMatch[1]!
+  // Last resort: construct from USER.
+  if (process.env.USER) return `/home/${process.env.USER}`
+  return home
+}
+
+/** The snap-adjusted home directory, resolved once at process start. */
+export const REAL_HOME = getRealHome()
+
+/**
+ * Normalize a home path and return it only when absolute, else null. Used to
+ * keep credential/cache path candidates from ever being built off a relative or
+ * empty home value.
+ */
+export function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}

--- a/src/server/llm/llm/openai-codex.test.ts
+++ b/src/server/llm/llm/openai-codex.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, it } from 'bun:test'
-import { STATIC_CODEX_MODELS, mapCodexModel } from './openai-codex'
+import { STATIC_CODEX_MODELS, mapCodexModel, modelsCacheCandidates } from './openai-codex'
 import { codexAccountIdFromTokens } from './_codex-auth'
 import type { PkceTokenResponse } from './_oauth-pkce'
+
+describe('modelsCacheCandidates', () => {
+  it('tries the env HOME before REAL_HOME (macOS: /Users vs the /home/$USER fallback)', () => {
+    // On macOS getRealHome() can wrongly yield /home/$USER; the real cache lives
+    // under /Users/$USER, so the env HOME candidate must be searched first.
+    expect(modelsCacheCandidates('/Users/tester', '/home/tester')).toEqual([
+      '/Users/tester/.codex/models_cache.json',
+      '/home/tester/.codex/models_cache.json',
+    ])
+  })
+
+  it('dedupes when env HOME and REAL_HOME match', () => {
+    expect(modelsCacheCandidates('/home/u', '/home/u')).toEqual(['/home/u/.codex/models_cache.json'])
+  })
+
+  it('falls back to REAL_HOME when env HOME is missing or relative', () => {
+    expect(modelsCacheCandidates(undefined, '/home/u')).toEqual(['/home/u/.codex/models_cache.json'])
+    expect(modelsCacheCandidates('relative/path', '/home/u')).toEqual(['/home/u/.codex/models_cache.json'])
+  })
+
+  it('never emits a relative candidate (drops non-absolute homes)', () => {
+    expect(modelsCacheCandidates('relative/env', 'also/relative')).toEqual([])
+    expect(modelsCacheCandidates(undefined, undefined)).toEqual([])
+    expect(modelsCacheCandidates('/Users/t', '')).toEqual(['/Users/t/.codex/models_cache.json'])
+  })
+})
 
 describe('STATIC_CODEX_MODELS (last-resort fallback catalog)', () => {
   it('ships at least one API-listable Codex slug', () => {

--- a/src/server/llm/llm/openai-codex.ts
+++ b/src/server/llm/llm/openai-codex.ts
@@ -17,7 +17,8 @@
  */
 
 import { existsSync, readFileSync } from 'fs'
-import { isAbsolute, join, normalize } from 'path'
+import { join } from 'path'
+import { REAL_HOME, normalizeAbsoluteHome } from '@/server/llm/llm/_home-paths'
 import {
   getCodexOAuthCredentials,
   CODEX_BASE_URL,
@@ -76,23 +77,6 @@ const CONFIG_SCHEMA: readonly ConfigField[] = [
 ]
 
 // ─── Model discovery ─────────────────────────────────────────────────────────
-
-function getRealHome(): string {
-  if (process.env.REAL_HOME) return process.env.REAL_HOME
-  const home = process.env.HOME ?? ''
-  const snapMatch = home.match(/^(\/home\/[^/]+)\/snap\//)
-  if (snapMatch) return snapMatch[1]!
-  if (process.env.USER) return `/home/${process.env.USER}`
-  return home
-}
-
-const REAL_HOME = getRealHome()
-
-function normalizeAbsoluteHome(home: string | undefined): string | null {
-  if (!home) return null
-  const normalized = normalize(home)
-  return isAbsolute(normalized) ? normalized : null
-}
 
 /**
  * Candidate cache paths, tried in order. The Codex CLI writes

--- a/src/server/llm/llm/openai-codex.ts
+++ b/src/server/llm/llm/openai-codex.ts
@@ -17,7 +17,7 @@
  */
 
 import { existsSync, readFileSync } from 'fs'
-import { join } from 'path'
+import { isAbsolute, join, normalize } from 'path'
 import {
   getCodexOAuthCredentials,
   CODEX_BASE_URL,
@@ -87,7 +87,31 @@ function getRealHome(): string {
 }
 
 const REAL_HOME = getRealHome()
-const MODELS_CACHE_PATH = join(REAL_HOME, '.codex', 'models_cache.json')
+
+function normalizeAbsoluteHome(home: string | undefined): string | null {
+  if (!home) return null
+  const normalized = normalize(home)
+  return isAbsolute(normalized) ? normalized : null
+}
+
+/**
+ * Candidate cache paths, tried in order. The Codex CLI writes
+ * `~/.codex/models_cache.json`, but the plain env HOME and the snap-adjusted
+ * REAL_HOME can differ (macOS and nonstandard Linux homes), so try the env HOME
+ * first and fall back to REAL_HOME rather than missing a valid cache.
+ * @internal exported for tests.
+ */
+export function modelsCacheCandidates(envHome: string | undefined, realHome: string | undefined): string[] {
+  const candidates: string[] = []
+  for (const home of [envHome, realHome]) {
+    const normalized = normalizeAbsoluteHome(home)
+    if (!normalized) continue
+    const p = join(normalized, '.codex', 'models_cache.json')
+    if (!candidates.includes(p)) candidates.push(p)
+  }
+  return candidates
+}
+const MODELS_CACHE_CANDIDATES = modelsCacheCandidates(process.env.HOME, REAL_HOME)
 
 interface CodexModelCacheEntry {
   slug: string
@@ -160,15 +184,18 @@ async function fetchCodexModelsFromApi(config: ProviderConfig): Promise<CodexMod
  * decide whether to error out or fall back).
  */
 function readCodexModelsFromCache(): CodexModelCacheEntry[] | null {
-  try {
-    if (!existsSync(MODELS_CACHE_PATH)) return null
-    const raw = readFileSync(MODELS_CACHE_PATH, 'utf8')
-    const parsed = JSON.parse(raw) as CodexModelsCacheFile
-    const selected = selectCodexEntries(parsed.models)
-    return selected.length > 0 ? selected : null
-  } catch {
-    return null
+  for (const path of MODELS_CACHE_CANDIDATES) {
+    try {
+      if (!existsSync(path)) continue
+      const raw = readFileSync(path, 'utf8')
+      const parsed = JSON.parse(raw) as CodexModelsCacheFile
+      const selected = selectCodexEntries(parsed.models)
+      if (selected.length > 0) return selected
+    } catch {
+      // try the next candidate path
+    }
   }
+  return null
 }
 
 /**


### PR DESCRIPTION
## Summary

Salvaged from #27 as a small standalone patch against current `main`, per @MarlBurroW's split suggestion. Blocker 3 (the `getRealHome` boot-crash) is already fixed on main, so this is purely the path-resolution improvement the review called out.

**The bug:** on macOS, `getRealHome()` returns `/home/$USER` (because `USER` is set and there's no snap path to strip) while the real home is `/Users/$USER`. A single `REAL_HOME`-derived path therefore misses the Codex CLI files entirely. The fix searches the plain env `HOME` first, then the snap-adjusted `REAL_HOME`:

- **`openai-codex.ts`** — `models_cache.json` is read from a candidate list, extracted as the pure, tested `modelsCacheCandidates()`.
- **`_codex-auth.ts`** — `~/.codex/auth.json` searched under env HOME then REAL_HOME.
- **`_anthropic-oauth-auth.ts`** — the three Claude credential filenames searched under env HOME then REAL_HOME.

Every home value is run through `normalizeAbsoluteHome` before use, so the builders never emit a relative candidate. When env HOME and REAL_HOME coincide (the common Linux case), the candidate lists collapse to the original single set — behavior there is unchanged.

## Validation

- `bun run typecheck` — PASS
- `bun run test` — PASS (added `modelsCacheCandidates` unit tests: macOS ordering, dedup, relative-home rejection)
- `bun run build` — PASS
- `git diff --check` — PASS
- CodeRabbit review — the two `normalizeAbsoluteHome`-consistency notes it raised are addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
