### PR TITLE
fix: make root Bun installs accessible to systemd

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,15 @@ jobs:
         run: |
           bash -n install.sh
           bash -n docker/entrypoint.sh
+          bash -n tests/install-bun-path.sh
+          bash -s -- --help < install.sh | grep -q '^USAGE$'
 
-      # ShellCheck the two shipped scripts only. severity:error means style/info
-      # findings never fail the build. ignore_paths excludes vendored/tooling
-      # scripts (husky, opencode patches, claude worktrees, node_modules) so the
-      # scan effectively covers install.sh + docker/entrypoint.sh.
+      - name: Test installer Bun service path
+        run: sudo bash tests/install-bun-path.sh
+
+      # ShellCheck the shipped scripts and installer regression test.
+      # severity:error means style/info findings never fail the build.
+      # ignore_paths excludes vendored and tooling scripts.
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,11 @@ HIVEKEEP_DRY_RUN=false
 HIVEKEEP_QUIET="${HIVEKEEP_QUIET:-false}"
 HIVEKEEP_START_TIME=""
 HIVEKEEP_YES="${HIVEKEEP_YES:-false}"
+HIVEKEEP_SYSTEM_BUN_INSTALL="/usr/local/lib/hivekeep/bun"
+HIVEKEEP_SYSTEM_CONFIG_DIR="/etc/hivekeep"
+HIVEKEEP_SYSTEMD_UNIT="/etc/systemd/system/hivekeep.service"
+HIVEKEEP_LEGACY_BUN_LINK="/usr/local/bin/bun"
+HIVEKEEP_LEGACY_BUN_ROOT="/root/.bun"
 
 # ─── Colors (auto-detect terminal support) ───────────────────────────────────
 setup_colors() {
@@ -774,6 +779,185 @@ ENV
 # Minimum Bun version required (lockfileVersion 1 needs Bun 1.2+)
 BUN_MIN_VERSION="1.2.0"
 
+configure_bun_environment() {
+  if [ -z "${BUN_INSTALL:-}" ]; then
+    if [ "${IS_ROOT:-false}" = true ] && [ "${OS:-$(uname -s)}" = "Linux" ]; then
+      BUN_INSTALL="$HIVEKEEP_SYSTEM_BUN_INSTALL"
+    else
+      BUN_INSTALL="$HOME/.bun"
+    fi
+  fi
+
+  export BUN_INSTALL
+  case ":${PATH:-}:" in
+    *":$BUN_INSTALL/bin:"*) ;;
+    *) export PATH="$BUN_INSTALL/bin:${PATH:-}" ;;
+  esac
+}
+
+prepare_managed_bun_directory() {
+  local managed_parent
+  managed_parent="$(dirname "$HIVEKEEP_SYSTEM_BUN_INSTALL")"
+
+  case "$HIVEKEEP_SYSTEM_BUN_INSTALL" in
+    /*) ;;
+    *) error "Managed Bun path must be absolute: $HIVEKEEP_SYSTEM_BUN_INSTALL" ;;
+  esac
+  case "$HIVEKEEP_SYSTEM_BUN_INSTALL" in
+    *[!A-Za-z0-9_./-]*) error "Managed Bun path contains unsupported characters: $HIVEKEEP_SYSTEM_BUN_INSTALL" ;;
+  esac
+
+  install -d -o root -g root -m 0755 \
+    "$managed_parent" \
+    "$HIVEKEEP_SYSTEM_BUN_INSTALL" \
+    "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin"
+
+  if [ -f "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun" ]; then
+    chown root:root "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun"
+    chmod 0755 "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun"
+  fi
+}
+
+canonical_executable_path() {
+  local executable="$1"
+  if command -v readlink &>/dev/null; then
+    readlink -f -- "$executable" 2>/dev/null && return 0
+  fi
+  if command -v realpath &>/dev/null; then
+    realpath "$executable" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+run_as_service_user() {
+  local executable="$1"
+  shift
+
+  local env_bin service_path
+  env_bin="$(command -v env 2>/dev/null || true)"
+  [ -n "$env_bin" ] || return 127
+  service_path="${executable%/*}:/usr/local/bin:/usr/bin:/bin"
+  local -a clean_command=(
+    "$env_bin" -i
+    "HOME=$HIVEKEEP_DIR"
+    "USER=$HIVEKEEP_USER"
+    "LOGNAME=$HIVEKEEP_USER"
+    "PATH=$service_path"
+    "$executable" "$@"
+  )
+
+  if command -v runuser &>/dev/null; then
+    runuser -u "$HIVEKEEP_USER" -- "${clean_command[@]}"
+    return
+  fi
+
+  if command -v su &>/dev/null && command -v sh &>/dev/null; then
+    local command="" arg quoted
+    for arg in "${clean_command[@]}"; do
+      printf -v quoted '%q' "$arg"
+      command+="${quoted} "
+    done
+    su -s "$(command -v sh)" -c "exec $command" "$HIVEKEEP_USER"
+    return
+  fi
+
+  return 127
+}
+
+bun_runs_as_service_user() {
+  run_as_service_user "$1" --version &>/dev/null
+}
+
+run_configured_bun() {
+  local executable="$1"
+  shift
+
+  if [ "${IS_ROOT:-false}" = true ] && [ "${OS:-}" = "Linux" ] && [ "${INIT_SYSTEM:-}" = "systemd" ]; then
+    id "$HIVEKEEP_USER" &>/dev/null || return 127
+    run_as_service_user "$executable" "$@"
+    return
+  fi
+
+  "$executable" "$@"
+}
+
+escape_systemd_environment_value() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//%/%%}"
+  printf '%s' "$value"
+}
+
+escape_systemd_exec_token() {
+  escape_systemd_environment_value "$1"
+}
+
+persist_bun_path() {
+  local path_dir="$HIVEKEEP_DATA_DIR"
+  if [ "${IS_ROOT:-false}" = true ]; then
+    path_dir="$HIVEKEEP_SYSTEM_CONFIG_DIR"
+    case "$path_dir" in
+      /*) ;;
+      *) error "System config path must be absolute: $path_dir" ;;
+    esac
+    case "$path_dir" in
+      *[!A-Za-z0-9_./-]*) error "System config path contains unsupported characters: $path_dir" ;;
+    esac
+    install -d -o root -g root -m 0755 "$path_dir"
+  else
+    mkdir -p "$path_dir"
+  fi
+
+  local path_file="$path_dir/bun.path"
+  local staged_path="${path_file}.tmp.$$"
+
+  case "$BUN_BIN" in
+    *$'\n'*|*$'\r'*) error "Bun path contains an unsupported newline" ;;
+  esac
+
+  rm -f "$staged_path"
+  printf '%s\n' "$BUN_BIN" > "$staged_path"
+  chmod 0644 "$staged_path"
+  if [ "${IS_ROOT:-false}" = true ]; then
+    chown root:root "$staged_path"
+  fi
+  mv -f "$staged_path" "$path_file"
+}
+
+configured_bun_path() {
+  local path_dir="$HIVEKEEP_DATA_DIR"
+  [ "${IS_ROOT:-false}" = true ] && path_dir="$HIVEKEEP_SYSTEM_CONFIG_DIR"
+  local path_file="$path_dir/bun.path"
+  local configured=""
+  if [ -f "$path_file" ]; then
+    if [ "${IS_ROOT:-false}" = true ]; then
+      local dir_owner dir_mode file_owner file_mode
+      dir_owner="$(stat -c '%U' "$path_dir" 2>/dev/null || stat -f '%Su' "$path_dir" 2>/dev/null || true)"
+      dir_mode="$(stat -c '%a' "$path_dir" 2>/dev/null || stat -f '%Lp' "$path_dir" 2>/dev/null || true)"
+      file_owner="$(stat -c '%U' "$path_file" 2>/dev/null || stat -f '%Su' "$path_file" 2>/dev/null || true)"
+      file_mode="$(stat -c '%a' "$path_file" 2>/dev/null || stat -f '%Lp' "$path_file" 2>/dev/null || true)"
+      [ "$dir_owner" = root ] || return 1
+      [ -n "$dir_mode" ] || return 1
+      (( (8#$dir_mode & 8#022) == 0 )) || return 1
+      [ "$file_owner" = root ] || return 1
+      [ -n "$file_mode" ] || return 1
+      (( (8#$file_mode & 8#022) == 0 )) || return 1
+    fi
+    IFS= read -r configured < "$path_file" || true
+    if [ -n "$configured" ] && [ -f "$configured" ]; then
+      printf '%s' "$configured"
+      return 0
+    fi
+    return 1
+  fi
+
+  local selected_bun
+  selected_bun="$(command -v bun 2>/dev/null || true)"
+  [ -n "$selected_bun" ] || return 1
+  canonical_executable_path "$selected_bun" || printf '%s' "$selected_bun"
+}
+
 # Compare two semver strings: returns 0 if $1 >= $2, 1 otherwise
 version_gte() {
   local IFS='.'
@@ -821,9 +1005,10 @@ ensure_bun() {
       ;;
   esac
 
-  BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-  export BUN_INSTALL
-  export PATH="$BUN_INSTALL/bin:$PATH"
+  configure_bun_environment
+  if [ "$IS_ROOT" = true ] && [ "$OS" = "Linux" ] && [ "$BUN_INSTALL" = "$HIVEKEEP_SYSTEM_BUN_INSTALL" ]; then
+    prepare_managed_bun_directory
+  fi
 
   if command -v bun &>/dev/null; then
     local current_version
@@ -1160,8 +1345,7 @@ rollback() {
 
       # Try to rebuild the old version so the service can restart
       info "Rebuilding previous version..."
-      BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-      export PATH="$BUN_INSTALL/bin:$PATH"
+      configure_bun_environment
       if command -v bun &>/dev/null; then
         cd "$HIVEKEEP_DIR"
         if bun install --frozen-lockfile &>/dev/null && bun run build &>/dev/null; then
@@ -1397,25 +1581,87 @@ setup_system_user() {
     success "User '$HIVEKEEP_USER' already exists"
   fi
 
-  chown -R "$HIVEKEEP_USER:$HIVEKEEP_USER" "$HIVEKEEP_DIR" "$HIVEKEEP_DATA_DIR"
+  local ownership_paths=()
+  [ -e "$HIVEKEEP_DIR" ] && ownership_paths+=("$HIVEKEEP_DIR")
+  [ -e "$HIVEKEEP_DATA_DIR" ] && ownership_paths+=("$HIVEKEEP_DATA_DIR")
+  if [ ${#ownership_paths[@]} -gt 0 ]; then
+    chown -R "$HIVEKEEP_USER:$HIVEKEEP_USER" "${ownership_paths[@]}"
+  fi
   success "Permissions set"
 }
 
 # ─── Resolve Bun path ────────────────────────────────────────────────────────
 resolve_bun_path() {
-  BUN_BIN="$(command -v bun)"
+  configure_bun_environment
 
-  if [ "$IS_ROOT" = true ] && [ "$BUN_BIN" != "/usr/local/bin/bun" ]; then
-    ln -sf "$BUN_BIN" /usr/local/bin/bun
-    BUN_BIN="/usr/local/bin/bun"
-    success "Bun symlinked to /usr/local/bin/bun"
+  local selected_bun
+  selected_bun="$(command -v bun 2>/dev/null || true)"
+  [ -n "$selected_bun" ] || error "Bun is not available on PATH after installation"
+
+  if [ "$IS_ROOT" != true ] || [ "$OS" != "Linux" ] || [ "${INIT_SYSTEM:-}" != "systemd" ]; then
+    BUN_BIN="$(canonical_executable_path "$selected_bun" || printf '%s' "$selected_bun")"
+    return 0
   fi
+
+  BUN_BIN="$(canonical_executable_path "$selected_bun" || true)"
+  [ -n "$BUN_BIN" ] || error "Could not resolve the Bun executable: $selected_bun"
+
+  id "$HIVEKEEP_USER" &>/dev/null || error "Service user '$HIVEKEEP_USER' does not exist"
+  if ! command -v runuser &>/dev/null && ! command -v su &>/dev/null; then
+    error "Cannot validate Bun as '$HIVEKEEP_USER': install runuser or su and retry"
+  fi
+
+  local path_requires_managed_copy=false
+  case "$BUN_BIN" in
+    *[!A-Za-z0-9_./-]*) path_requires_managed_copy=true ;;
+  esac
+
+  if [ "$path_requires_managed_copy" = false ] && bun_runs_as_service_user "$BUN_BIN"; then
+    success "Bun is executable by '$HIVEKEEP_USER' ($BUN_BIN)"
+    return 0
+  fi
+
+  prepare_managed_bun_directory
+
+  local managed_bun="$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun"
+  local managed_canonical=""
+  managed_canonical="$(canonical_executable_path "$managed_bun" || true)"
+
+  if [ -n "$managed_canonical" ] && [ "$BUN_BIN" = "$managed_canonical" ]; then
+    BUN_BIN="$managed_bun"
+    bun_runs_as_service_user "$BUN_BIN" || \
+      error "Managed Bun is not executable by '$HIVEKEEP_USER': $BUN_BIN"
+    success "Bun permissions repaired for '$HIVEKEEP_USER' ($BUN_BIN)"
+    return 0
+  fi
+
+  local staged_bun="${managed_bun}.tmp.$$"
+  rm -f "$staged_bun"
+  install -o root -g root -m 0755 "$BUN_BIN" "$staged_bun"
+
+  if ! bun_runs_as_service_user "$staged_bun"; then
+    rm -f "$staged_bun"
+    error "Bun cannot execute as '$HIVEKEEP_USER' after staging it at $staged_bun"
+  fi
+
+  mv -f "$staged_bun" "$managed_bun"
+  chown root:root "$managed_bun"
+  chmod 0755 "$managed_bun"
+  BUN_BIN="$managed_bun"
+
+  bun_runs_as_service_user "$BUN_BIN" || \
+    error "Managed Bun is not executable by '$HIVEKEEP_USER': $BUN_BIN"
+  success "Bun prepared for '$HIVEKEEP_USER' ($BUN_BIN)"
 }
 
 # ─── Service: systemd system (root) ──────────────────────────────────────────
 create_systemd_system_service() {
   local env_file="$HIVEKEEP_DATA_DIR/hivekeep.env"
-  UNIT_FILE="/etc/systemd/system/hivekeep.service"
+  local bun_dir
+  local escaped_bun_bin
+  bun_dir="$(dirname "$BUN_BIN")"
+  escaped_bun_bin="$(escape_systemd_exec_token "$BUN_BIN")"
+  UNIT_FILE="$HIVEKEEP_SYSTEMD_UNIT"
 
   if [ "$IS_UPDATE" = true ] && systemctl is-active --quiet hivekeep 2>/dev/null; then
     info "Stopping existing service..."
@@ -1435,7 +1681,8 @@ User=$HIVEKEEP_USER
 Group=$HIVEKEEP_USER
 WorkingDirectory=$HIVEKEEP_DIR
 EnvironmentFile=-${env_file}
-ExecStart=$BUN_BIN src/server/index.ts
+Environment="PATH=${bun_dir}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ExecStart="$escaped_bun_bin" src/server/index.ts
 Restart=always
 RestartSec=5
 StandardOutput=journal
@@ -1448,13 +1695,71 @@ UNIT
 
   systemctl daemon-reload
   systemctl enable hivekeep
+  systemctl reset-failed hivekeep 2>/dev/null || true
   systemctl start hivekeep
   success "systemd system service started"
+}
+
+legacy_system_bun_service_needs_repair() {
+  [ "$(id -u)" -eq 0 ] || return 1
+  [ "$(uname -s)" = "Linux" ] || return 1
+  [ -f "$HIVEKEEP_SYSTEMD_UNIT" ] || return 1
+  [ -L "$HIVEKEEP_LEGACY_BUN_LINK" ] || return 1
+  grep -Fq "ExecStart=$HIVEKEEP_LEGACY_BUN_LINK " "$HIVEKEEP_SYSTEMD_UNIT" || return 1
+
+  local legacy_target
+  legacy_target="$(canonical_executable_path "$HIVEKEEP_LEGACY_BUN_LINK" || true)"
+  case "$legacy_target" in
+    "${HIVEKEEP_LEGACY_BUN_ROOT%/}"/*) ;;
+    *) return 1 ;;
+  esac
+
+  id "$HIVEKEEP_USER" &>/dev/null || return 1
+  ! bun_runs_as_service_user "$HIVEKEEP_LEGACY_BUN_LINK"
+}
+
+repair_legacy_system_bun_service() {
+  info "Repairing the legacy root-only Bun service path..."
+  detect_os
+  configure_bun_environment
+  setup_system_user
+  resolve_bun_path
+
+  local previous_is_update="${IS_UPDATE:-false}"
+  IS_UPDATE=true
+  create_systemd_system_service
+  IS_UPDATE="$previous_is_update"
+  persist_bun_path
+
+  local env_file="$HIVEKEEP_DATA_DIR/hivekeep.env"
+  if [ -f "$env_file" ]; then
+    local configured_port
+    configured_port="$(grep '^PORT=' "$env_file" 2>/dev/null | tail -1 | cut -d= -f2 || true)"
+    [ -n "$configured_port" ] && HIVEKEEP_PORT="$configured_port"
+  fi
+
+  HIVEKEEP_HEALTHY=false
+  verify_running
+  [ "$HIVEKEEP_HEALTHY" = true ] || error "Legacy Bun path was migrated, but Hivekeep did not become healthy"
+
+  systemctl is-active --quiet hivekeep || error "Legacy Bun path was migrated, but the systemd service is not active"
+  local main_pid exec_status
+  main_pid="$(systemctl show hivekeep -p MainPID --value 2>/dev/null || echo 0)"
+  exec_status="$(systemctl show hivekeep -p ExecMainStatus --value 2>/dev/null || echo 1)"
+  [ "$main_pid" -gt 0 ] 2>/dev/null || error "Legacy Bun path was migrated, but systemd has no Hivekeep process"
+  [ "$exec_status" = "0" ] || error "Legacy Bun path was migrated, but systemd reports exit status $exec_status"
+  success "Legacy Bun service path migrated to $BUN_BIN"
 }
 
 # ─── Service: systemd user (non-root) ────────────────────────────────────────
 create_systemd_user_service() {
   local env_file="$HIVEKEEP_DATA_DIR/hivekeep.env"
+  local bun_dir
+  local escaped_bun_bin
+  local service_path
+  bun_dir="$(dirname "$BUN_BIN")"
+  escaped_bun_bin="$(escape_systemd_exec_token "$BUN_BIN")"
+  service_path="$(escape_systemd_environment_value "${bun_dir}:${PATH:-/usr/local/bin:/usr/bin:/bin}")"
   UNIT_DIR="$HOME/.config/systemd/user"
   UNIT_FILE="$UNIT_DIR/hivekeep.service"
 
@@ -1474,7 +1779,8 @@ After=network.target
 Type=simple
 WorkingDirectory=$HIVEKEEP_DIR
 EnvironmentFile=-${env_file}
-ExecStart=$BUN_BIN src/server/index.ts
+Environment="PATH=${service_path}"
+ExecStart="$escaped_bun_bin" src/server/index.ts
 Restart=always
 RestartSec=5
 
@@ -2023,6 +2329,8 @@ create_service() {
   else
     create_systemd_user_service
   fi
+
+  persist_bun_path
 }
 
 # ─── Post-start health check ─────────────────────────────────────────────────
@@ -2362,6 +2670,9 @@ uninstall() {
   echo ""
 
   detect_os
+  configure_bun_environment
+  local retained_bun_path
+  retained_bun_path="$(configured_bun_path || true)"
 
   # Stop and disable service
   header "Stopping service..."
@@ -2404,6 +2715,13 @@ uninstall() {
     rm -f "$HOME/.config/systemd/user/hivekeep.service"
     systemctl --user daemon-reload
     success "systemd user service removed"
+  fi
+
+  if [ "$IS_ROOT" = true ]; then
+    rm -f "$HIVEKEEP_SYSTEM_CONFIG_DIR/bun.path"
+    rmdir "$HIVEKEEP_SYSTEM_CONFIG_DIR" 2>/dev/null || true
+  else
+    rm -f "$HIVEKEEP_DATA_DIR/bun.path"
   fi
 
   # Remove app directory
@@ -2526,8 +2844,8 @@ uninstall() {
 
   # Post-uninstall hints
   local hints=()
-  if command -v bun &>/dev/null; then
-    hints+=("Bun runtime is still installed. Remove it with: rm -rf ~/.bun")
+  if [ -n "$retained_bun_path" ] && [ -f "$retained_bun_path" ]; then
+    hints+=("Bun runtime is still installed at $retained_bun_path")
   fi
   if [ -d "$HIVEKEEP_DATA_DIR" ] && [[ ! "$remove_data" =~ ^[Yy]$ ]]; then
     hints+=("Data preserved at $HIVEKEEP_DATA_DIR (re-install will reuse it)")
@@ -2972,19 +3290,29 @@ check_status() {
 
   # Check Bun
   header "Runtime"
-  BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-  export PATH="$BUN_INSTALL/bin:$PATH"
-  if command -v bun &>/dev/null; then
+  configure_bun_environment
+  local doctor_bun
+  doctor_bun="$(configured_bun_path || true)"
+  if [ -n "$doctor_bun" ]; then
     local bun_ver
-    bun_ver="$(bun --version 2>/dev/null || echo "0.0.0")"
+    bun_ver="$(run_configured_bun "$doctor_bun" --version 2>/dev/null || echo "0.0.0")"
     if version_gte "$bun_ver" "$BUN_MIN_VERSION"; then
       success "Bun v${bun_ver}"
     else
       warn "Bun v${bun_ver} is outdated (need v${BUN_MIN_VERSION}+). Run the installer to upgrade."
       has_issues=true
     fi
+
+    if [ "$IS_ROOT" = true ] && [ "$OS" = "Linux" ] && [ "${INIT_SYSTEM:-}" = "systemd" ] && id "$HIVEKEEP_USER" &>/dev/null; then
+      if bun_runs_as_service_user "$doctor_bun"; then
+        success "Bun is executable by '$HIVEKEEP_USER'"
+      else
+        warn "Bun cannot execute as '$HIVEKEEP_USER' ($doctor_bun)"
+        has_issues=true
+      fi
+    fi
   else
-    warn "Bun not found"
+    warn "Configured Bun runtime not found"
     has_issues=true
   fi
 
@@ -3550,10 +3878,18 @@ do_doctor() {
 
   # ── Runtime ──
   echo "## Runtime"
-  BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-  export PATH="$BUN_INSTALL/bin:$PATH"
-  if command -v bun &>/dev/null; then
-    echo "- Bun: $(bun --version 2>/dev/null || echo error) ($(command -v bun))"
+  configure_bun_environment
+  local diagnose_bun
+  diagnose_bun="$(configured_bun_path || true)"
+  if [ -n "$diagnose_bun" ]; then
+    echo "- Bun: $(run_configured_bun "$diagnose_bun" --version 2>/dev/null || echo error) ($diagnose_bun)"
+    if [ "$IS_ROOT" = true ] && [ "$OS" = "Linux" ] && [ "${INIT_SYSTEM:-}" = "systemd" ] && id "$HIVEKEEP_USER" &>/dev/null; then
+      if bun_runs_as_service_user "$diagnose_bun"; then
+        echo "- Service user Bun execution: ok ($HIVEKEEP_USER)"
+      else
+        echo "- Service user Bun execution: FAILED ($HIVEKEEP_USER)"
+      fi
+    fi
   else
     echo "- Bun: NOT FOUND"
   fi
@@ -3799,8 +4135,7 @@ dry_run() {
   done
 
   # Bun
-  BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-  export PATH="$BUN_INSTALL/bin:$PATH"
+  configure_bun_environment
   if command -v bun &>/dev/null; then
     local bun_ver
     bun_ver="$(bun --version 2>/dev/null || echo "0.0.0")"
@@ -5001,6 +5336,9 @@ do_update() {
   if [ "$local_head" = "$remote_head" ]; then
     local version
     version="$(git -C "$HIVEKEEP_DIR" describe --tags 2>/dev/null || git -C "$HIVEKEEP_DIR" rev-parse --short HEAD)"
+    if legacy_system_bun_service_needs_repair; then
+      repair_legacy_system_bun_service
+    fi
     echo ""
     echo -e "  ${GREEN}✓ Already up to date${NC} ($version, $channel channel)"
     echo ""
@@ -5177,6 +5515,11 @@ do_reset() {
   STEP_TOTAL=7
   STEP_CURRENT=0
 
+  # Validate the runtime before stopping the service or removing the checkout.
+  ensure_bun
+  setup_system_user
+  resolve_bun_path
+
   # 1. Back up the database
   step "Backing up database"
   backup_database
@@ -5245,7 +5588,6 @@ do_reset() {
   success "Cloned $new_version"
 
   # 5. Rebuild
-  ensure_bun
   IS_UPDATE=true
   build_hivekeep
   setup_database
@@ -5436,6 +5778,13 @@ do_test() {
     HIVEKEEP_DIR="${HIVEKEEP_DIR:-$HOME/hivekeep}"
     HIVEKEEP_DATA_DIR="${HIVEKEEP_DATA_DIR:-$HOME/.local/share/hivekeep}"
   fi
+  if [ "$OS" = "Darwin" ]; then
+    INIT_SYSTEM="launchd"
+  elif command -v systemctl &>/dev/null && systemctl --version &>/dev/null 2>&1; then
+    INIT_SYSTEM="systemd"
+  else
+    INIT_SYSTEM="script"
+  fi
 
   local passed=0
   local failed=0
@@ -5511,11 +5860,12 @@ do_test() {
 
   # ── 3. Runtime ──
   header "Runtime"
-  BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
-  export PATH="$BUN_INSTALL/bin:$PATH"
-  if command -v bun &>/dev/null; then
+  configure_bun_environment
+  local test_bun
+  test_bun="$(configured_bun_path || true)"
+  if [ -n "$test_bun" ]; then
     local bun_ver
-    bun_ver="$(bun --version 2>/dev/null || echo "0.0.0")"
+    bun_ver="$(run_configured_bun "$test_bun" --version 2>/dev/null || echo "0.0.0")"
     BUN_MIN_VERSION="${BUN_MIN_VERSION:-1.2.0}"
     if version_gte "$bun_ver" "$BUN_MIN_VERSION"; then
       test_pass "Bun v${bun_ver} (meets v${BUN_MIN_VERSION}+ requirement)"
@@ -5524,13 +5874,21 @@ do_test() {
     fi
 
     # Verify Bun can actually execute (not just present on PATH)
-    if bun -e "console.log('ok')" 2>/dev/null | grep -q "ok"; then
+    if run_configured_bun "$test_bun" -e "console.log('ok')" 2>/dev/null | grep -q "ok"; then
       test_pass "Bun runtime is functional"
     else
-      test_fail "Bun is on PATH but cannot execute JavaScript"
+      test_fail "Configured Bun runtime cannot execute JavaScript"
+    fi
+
+    if [ "$IS_ROOT" = true ] && [ "$OS" = "Linux" ] && [ "${INIT_SYSTEM:-}" = "systemd" ] && id "$HIVEKEEP_USER" &>/dev/null; then
+      if bun_runs_as_service_user "$test_bun"; then
+        test_pass "Bun executes as service user '$HIVEKEEP_USER'"
+      else
+        test_fail "Bun cannot execute as service user '$HIVEKEEP_USER' ($test_bun)"
+      fi
     fi
   else
-    test_fail "Bun not found on PATH"
+    test_fail "Configured Bun runtime not found"
   fi
 
   # ── 4. Configuration ──
@@ -6479,4 +6837,6 @@ main() {
   print_summary
 }
 
-main "$@"
+if [ -z "${BASH_SOURCE[0]:-}" ] || [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -1659,8 +1659,10 @@ create_systemd_system_service() {
   local env_file="$HIVEKEEP_DATA_DIR/hivekeep.env"
   local bun_dir
   local escaped_bun_bin
+  local service_path
   bun_dir="$(dirname "$BUN_BIN")"
   escaped_bun_bin="$(escape_systemd_exec_token "$BUN_BIN")"
+  service_path="$(escape_systemd_environment_value "${bun_dir}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")"
   UNIT_FILE="$HIVEKEEP_SYSTEMD_UNIT"
 
   if [ "$IS_UPDATE" = true ] && systemctl is-active --quiet hivekeep 2>/dev/null; then
@@ -1681,7 +1683,7 @@ User=$HIVEKEEP_USER
 Group=$HIVEKEEP_USER
 WorkingDirectory=$HIVEKEEP_DIR
 EnvironmentFile=-${env_file}
-Environment="PATH=${bun_dir}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+Environment="PATH=${service_path}"
 ExecStart="$escaped_bun_bin" src/server/index.ts
 Restart=always
 RestartSec=5

--- a/tests/install-bun-path.sh
+++ b/tests/install-bun-path.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This test must run as root." >&2
+  exit 1
+fi
+
+TEST_ROOT="$(mktemp -d /tmp/hivekeep-bun-path-test.XXXXXX)"
+TEST_USER="hk-bun-$$-$RANDOM"
+PRIVATE_DIR="$(mktemp -d /root/hivekeep-bun-path-test.XXXXXX)"
+ORIGINAL_PATH="$PATH"
+USERDEL_BIN="$(command -v userdel)"
+LOGINCTL_BIN="$(command -v loginctl 2>/dev/null || true)"
+USER_CREATED=false
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cleanup() {
+  local cleanup_status=$?
+  if [ "$USER_CREATED" = true ]; then
+    if [ -n "$LOGINCTL_BIN" ]; then
+      "$LOGINCTL_BIN" terminate-user "$TEST_USER" 2>/dev/null || true
+    fi
+    local attempt userdel_error=""
+    for attempt in 1 2 3 4 5 6 7 8 9 10; do
+      if userdel_error="$("$USERDEL_BIN" "$TEST_USER" 2>&1)"; then
+        break
+      fi
+      /bin/sleep 1
+    done
+    if id "$TEST_USER" &>/dev/null; then
+      echo "Failed to remove test user $TEST_USER: $userdel_error" >&2
+      cleanup_status=1
+    fi
+  fi
+  rm -rf "$PRIVATE_DIR" "$TEST_ROOT"
+  trap - EXIT
+  exit "$cleanup_status"
+}
+trap cleanup EXIT
+
+chmod 0755 "$TEST_ROOT"
+useradd --system --no-create-home --shell /usr/sbin/nologin "$TEST_USER"
+USER_CREATED=true
+
+# shellcheck source=../install.sh
+source "$SCRIPT_DIR/../install.sh"
+PRODUCTION_SYSTEM_BUN_INSTALL="$HIVEKEEP_SYSTEM_BUN_INSTALL"
+PRODUCTION_SYSTEM_CONFIG_DIR="$HIVEKEEP_SYSTEM_CONFIG_DIR"
+HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-default"
+HIVEKEEP_SYSTEM_CONFIG_DIR="$TEST_ROOT/system-config"
+
+pass_count=0
+
+pass() {
+  pass_count=$((pass_count + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_equal() {
+  local expected="$1" actual="$2" message="$3"
+  [ "$expected" = "$actual" ] || fail "$message (expected '$expected', got '$actual')"
+}
+
+make_bun() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' '#!/bin/sh' 'printf "1.3.14\n"' > "$path"
+  chmod 0755 "$path"
+}
+
+test_stdin_entrypoint() {
+  local help_output
+  help_output="$(bash -s -- --help < "$SCRIPT_DIR/../install.sh")"
+  grep -q '^USAGE$' <<< "$help_output" || fail "stdin installer entrypoint did not run main"
+}
+test_stdin_entrypoint
+pass "Curl-to-bash stdin entrypoint"
+
+test_environment_defaults() (
+  assert_equal "/usr/local/lib/hivekeep/bun" "$PRODUCTION_SYSTEM_BUN_INSTALL" "production managed Bun path"
+  assert_equal "/etc/hivekeep" "$PRODUCTION_SYSTEM_CONFIG_DIR" "production system config path"
+
+  IS_ROOT=true
+  OS=Linux
+  PATH="$ORIGINAL_PATH"
+  unset BUN_INSTALL
+  configure_bun_environment
+  assert_equal "$HIVEKEEP_SYSTEM_BUN_INSTALL" "$BUN_INSTALL" "root Linux default"
+
+  IS_ROOT=false
+  HOME="$TEST_ROOT/non-root-home"
+  PATH="$ORIGINAL_PATH"
+  unset BUN_INSTALL
+  configure_bun_environment
+  assert_equal "$HOME/.bun" "$BUN_INSTALL" "non-root default"
+
+  IS_ROOT=true
+  OS=Linux
+  PATH="$ORIGINAL_PATH"
+  BUN_INSTALL="$TEST_ROOT/explicit-bun"
+  configure_bun_environment
+  assert_equal "$TEST_ROOT/explicit-bun" "$BUN_INSTALL" "explicit BUN_INSTALL"
+)
+test_environment_defaults
+pass "Bun environment defaults"
+
+test_systemd_escaping() (
+  assert_equal '/tmp/$bun%%path' "$(escape_systemd_environment_value '/tmp/$bun%path')" \
+    "systemd Environment value escaping"
+  assert_equal '/tmp/$bun%%path' "$(escape_systemd_exec_token '/tmp/$bun%path')" \
+    "systemd ExecStart token escaping"
+)
+test_systemd_escaping
+pass "Systemd service values escape ExecStart expansion separately"
+
+test_systemd_user_unit() (
+  local unit_home="$TEST_ROOT/systemd-user-home"
+  local user_bun="$TEST_ROOT/user "'$cash'"/bin/bun"
+  local escaped_bun
+  make_bun "$user_bun"
+  mkdir -p "$unit_home/app" "$unit_home/data"
+
+  IS_ROOT=false
+  IS_UPDATE=false
+  HOME="$unit_home"
+  HIVEKEEP_DIR="$unit_home/app"
+  HIVEKEEP_DATA_DIR="$unit_home/data"
+  BUN_BIN="$user_bun"
+  systemctl() { return 0; }
+  loginctl() { return 0; }
+  create_systemd_user_service &>/dev/null
+
+  escaped_bun="$(escape_systemd_exec_token "$BUN_BIN")"
+  grep -Fq "ExecStart=\"$escaped_bun\" src/server/index.ts" "$UNIT_FILE" || \
+    fail "generated systemd user unit lost the literal Bun path"
+  if command -v systemd-analyze &>/dev/null; then
+    systemd-analyze verify "$UNIT_FILE" || fail "generated systemd user unit failed verification"
+  fi
+)
+test_systemd_user_unit
+pass "Generated systemd user unit preserves and validates the Bun path"
+
+test_systemd_system_unit() (
+  local system_bun="$TEST_ROOT/system-runtime/bin/bun"
+  local system_unit="$TEST_ROOT/system-hivekeep.service"
+  local systemctl_log="$TEST_ROOT/systemctl-calls"
+  local -a systemctl_calls
+  make_bun "$system_bun"
+  mkdir -p "$TEST_ROOT/system-app" "$TEST_ROOT/system-data"
+
+  IS_ROOT=true
+  IS_UPDATE=false
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_DIR="$TEST_ROOT/system-app"
+  HIVEKEEP_DATA_DIR="$TEST_ROOT/system-data"
+  HIVEKEEP_SYSTEMD_UNIT="$system_unit"
+  BUN_BIN="$system_bun"
+  systemctl() { printf '%s\n' "$*" >> "$systemctl_log"; }
+  create_systemd_system_service &>/dev/null
+
+  grep -Fq "User=$TEST_USER" "$UNIT_FILE" || fail "systemd system unit lost its service user"
+  grep -Fq "Group=$TEST_USER" "$UNIT_FILE" || fail "systemd system unit lost its service group"
+  grep -Fq "ExecStart=\"$system_bun\" src/server/index.ts" "$UNIT_FILE" || \
+    fail "systemd system unit lost the verified Bun path"
+  grep -Fq "Environment=\"PATH=$(dirname "$system_bun"):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" "$UNIT_FILE" || \
+    fail "systemd system unit lost the Bun service PATH"
+  if command -v systemd-analyze &>/dev/null; then
+    systemd-analyze verify "$UNIT_FILE" || fail "generated systemd system unit failed verification"
+  fi
+  mapfile -t systemctl_calls < "$systemctl_log"
+  assert_equal "daemon-reload" "${systemctl_calls[0]}" "systemd reload order"
+  assert_equal "enable hivekeep" "${systemctl_calls[1]}" "systemd enable order"
+  assert_equal "reset-failed hivekeep" "${systemctl_calls[2]}" "systemd start-limit reset order"
+  assert_equal "start hivekeep" "${systemctl_calls[3]}" "systemd start order"
+)
+test_systemd_system_unit
+pass "Generated systemd system unit uses the service user and verified Bun path"
+
+test_persisted_bun_path() (
+  local persisted_bun="$TEST_ROOT/persisted runtime/bun"
+  local stat_only_path="$TEST_ROOT/stat-only"
+  local service_uid
+  make_bun "$persisted_bun"
+  chown "$TEST_USER:$TEST_USER" "$persisted_bun"
+  mkdir -p "$stat_only_path"
+  ln -s /usr/bin/stat "$stat_only_path/stat"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=systemd
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_DATA_DIR="$TEST_ROOT/persisted-data"
+  HIVEKEEP_SYSTEM_CONFIG_DIR="$TEST_ROOT/persisted-config"
+  BUN_BIN="$persisted_bun"
+  persist_bun_path
+
+  assert_equal root "$(stat -c '%U' "$HIVEKEEP_SYSTEM_CONFIG_DIR/bun.path")" \
+    "persisted service Bun path owner"
+  export HIVEKEEP_REVIEW_SECRET=visible-to-root
+  if run_configured_bun /usr/bin/env | grep -q HIVEKEEP_REVIEW_SECRET; then
+    fail "root environment leaked into service-user diagnostics"
+  fi
+  service_uid="$(run_configured_bun /usr/bin/id -u)"
+  assert_equal "$(/usr/bin/id -u "$TEST_USER")" "$service_uid" "root diagnostic execution user"
+  PATH="$stat_only_path"
+  assert_equal "$persisted_bun" "$(configured_bun_path)" "persisted service Bun path"
+
+  PATH="$ORIGINAL_PATH"
+  rm -f "$persisted_bun"
+  PATH="$stat_only_path"
+  if configured_bun_path &>/dev/null; then
+    fail "root diagnostics replaced a stale configured Bun path with PATH discovery"
+  fi
+
+  PATH="$ORIGINAL_PATH"
+  make_bun "$persisted_bun"
+  chown "$TEST_USER:$TEST_USER" "$persisted_bun"
+  chown "$TEST_USER:$TEST_USER" "$HIVEKEEP_SYSTEM_CONFIG_DIR/bun.path"
+  PATH="$stat_only_path"
+  if configured_bun_path &>/dev/null; then
+    fail "root diagnostics trusted service-owned Bun metadata"
+  fi
+)
+test_persisted_bun_path
+pass "Root diagnostics trust root-owned metadata and drop service privileges"
+
+test_accessible_system_bun() (
+  local selected_dir="$TEST_ROOT/accessible/bin"
+  local selected_bun="$selected_dir/bun"
+  local before_hash after_hash
+  install -d -m 0755 "$selected_dir"
+  make_bun "$selected_bun"
+  before_hash="$(sha256sum "$selected_bun" | awk '{print $1}')"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=systemd
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-accessible"
+  BUN_INSTALL="$TEST_ROOT/accessible"
+  PATH="$selected_dir:$ORIGINAL_PATH"
+  resolve_bun_path
+
+  after_hash="$(sha256sum "$selected_bun" | awk '{print $1}')"
+  assert_equal "$before_hash" "$after_hash" "accessible Bun checksum"
+  [ ! -L "$selected_bun" ] || fail "accessible Bun became a symlink"
+  assert_equal "$selected_bun" "$BUN_BIN" "accessible Bun path"
+)
+test_accessible_system_bun
+pass "Accessible system Bun remains unchanged"
+
+test_legacy_private_bun() (
+  local private_bun="$PRIVATE_DIR/legacy/bin/bun"
+  local legacy_dir="$TEST_ROOT/legacy-link"
+  local legacy_link="$legacy_dir/bun"
+  local original_target
+
+  mkdir -p "$(dirname "$private_bun")" "$legacy_dir"
+  chmod 0700 "$PRIVATE_DIR" "$(dirname "$PRIVATE_DIR/legacy")" 2>/dev/null || true
+  make_bun "$private_bun"
+  chmod 0700 "$PRIVATE_DIR"
+  chmod 0755 "$legacy_dir"
+  ln -s "$private_bun" "$legacy_link"
+  original_target="$(readlink "$legacy_link")"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=systemd
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-legacy"
+  BUN_INSTALL=""
+  PATH="$legacy_dir:$ORIGINAL_PATH"
+  umask 077
+
+  bun_runs_as_service_user "$legacy_link" && fail "legacy private Bun unexpectedly executed"
+  resolve_bun_path
+
+  assert_equal "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun" "$BUN_BIN" "managed legacy Bun path"
+  assert_equal "$original_target" "$(readlink "$legacy_link")" "legacy symlink preservation"
+  bun_runs_as_service_user "$BUN_BIN" || fail "managed Bun did not execute as service user"
+  assert_equal "755" "$(stat -c '%a' "$(dirname "$HIVEKEEP_SYSTEM_BUN_INSTALL")")" "managed parent mode"
+  assert_equal "755" "$(stat -c '%a' "$HIVEKEEP_SYSTEM_BUN_INSTALL")" "managed directory mode"
+  assert_equal "755" "$(stat -c '%a' "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin")" "managed bin mode"
+  assert_equal "755" "$(stat -c '%a' "$BUN_BIN")" "managed Bun mode"
+
+  local service_path
+  service_path="$(dirname "$BUN_BIN"):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  run_as_service_user env "PATH=$service_path" bun --version &>/dev/null || \
+    fail "bare bun was unavailable with the service PATH"
+)
+test_legacy_private_bun
+pass "Legacy private Bun migrates without changing its symlink"
+
+test_legacy_repair_dispatch() (
+  local private_bun="$PRIVATE_DIR/repair/bin/bun"
+  local legacy_link="$TEST_ROOT/repair-link/bun"
+  local unit_file="$TEST_ROOT/hivekeep.service"
+  mkdir -p "$(dirname "$private_bun")" "$(dirname "$legacy_link")" "$TEST_ROOT/repair-data"
+  make_bun "$private_bun"
+  chmod 0700 "$PRIVATE_DIR"
+  ln -s "$private_bun" "$legacy_link"
+  printf 'ExecStart=%s src/server/index.ts\n' "$legacy_link" > "$unit_file"
+
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_SYSTEMD_UNIT="$unit_file"
+  HIVEKEEP_LEGACY_BUN_LINK="$legacy_link"
+  HIVEKEEP_LEGACY_BUN_ROOT="$PRIVATE_DIR"
+  legacy_system_bun_service_needs_repair || fail "legacy detector missed the root-only service path"
+
+  local setup_called=false service_called=false
+  HIVEKEEP_DATA_DIR="$TEST_ROOT/repair-data"
+  detect_os() { OS=Linux; INIT_SYSTEM=systemd; }
+  configure_bun_environment() { :; }
+  setup_system_user() { setup_called=true; }
+  resolve_bun_path() { BUN_BIN="$TEST_ROOT/repaired-bun"; }
+  create_systemd_system_service() { service_called=true; }
+  verify_running() { HIVEKEEP_HEALTHY=true; }
+  systemctl() {
+    case "$1" in
+      is-active) return 0 ;;
+      show)
+        case "$*" in
+          *MainPID*) echo 123 ;;
+          *ExecMainStatus*) echo 0 ;;
+        esac
+        ;;
+    esac
+  }
+
+  repair_legacy_system_bun_service &>/dev/null
+  [ "$setup_called" = true ] || fail "legacy repair skipped service-user setup"
+  [ "$service_called" = true ] || fail "legacy repair skipped service recreation"
+)
+test_legacy_repair_dispatch
+pass "Legacy detector and repair dispatch"
+
+test_explicit_inaccessible_install() (
+  local private_install="$PRIVATE_DIR/explicit"
+  local private_bun="$private_install/bin/bun"
+  mkdir -p "$(dirname "$private_bun")"
+  make_bun "$private_bun"
+  chmod 0700 "$PRIVATE_DIR"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=systemd
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-explicit"
+  BUN_INSTALL="$private_install"
+  PATH="$private_install/bin:$ORIGINAL_PATH"
+  resolve_bun_path
+
+  assert_equal "$private_install" "$BUN_INSTALL" "explicit BUN_INSTALL preservation"
+  assert_equal "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun" "$BUN_BIN" "explicit fallback path"
+  bun_runs_as_service_user "$BUN_BIN" || fail "explicit fallback did not execute"
+)
+test_explicit_inaccessible_install
+pass "Inaccessible explicit BUN_INSTALL uses the managed fallback"
+
+test_su_fallback() (
+  local fallback_path="$TEST_ROOT/su-fallback-path"
+  local selected_bun="$TEST_ROOT/su-fallback-bun"
+  local service_environment
+  install -d -m 0755 "$fallback_path"
+  ln -s "$(command -v su)" "$fallback_path/su"
+  ln -s "$(command -v sh)" "$fallback_path/sh"
+  ln -s "$(command -v env)" "$fallback_path/env"
+  make_bun "$selected_bun"
+
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_DIR="$TEST_ROOT/su-fallback-home"
+  export HIVEKEEP_REVIEW_SECRET=visible-to-root
+  PATH="$fallback_path"
+  run_as_service_user "$selected_bun" --version &>/dev/null || fail "su fallback failed"
+  service_environment="$(run_as_service_user /usr/bin/env)"
+  PATH="$ORIGINAL_PATH"
+  if grep -q HIVEKEEP_REVIEW_SECRET <<< "$service_environment"; then
+    fail "su fallback leaked the root environment"
+  fi
+)
+test_su_fallback
+pass "Service-user validation falls back to su"
+
+test_root_script_service() (
+  local private_install="$PRIVATE_DIR/script-service"
+  local private_bun="$private_install/bin/bun"
+  mkdir -p "$(dirname "$private_bun")"
+  make_bun "$private_bun"
+  chmod 0700 "$PRIVATE_DIR"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=script
+  HIVEKEEP_USER="missing-service-user"
+  HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-script-service"
+  BUN_INSTALL="$private_install"
+  PATH="$private_install/bin:$ORIGINAL_PATH"
+  resolve_bun_path
+
+  assert_equal "$private_bun" "$BUN_BIN" "root script service Bun path"
+  [ ! -e "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun" ] || fail "script service created an unnecessary managed Bun"
+)
+test_root_script_service
+pass "Root script service does not require an unprivileged service user"
+
+test_setup_user_with_missing_install_dir() (
+  local existing_data="$TEST_ROOT/reset-data-only"
+  local missing_install="$TEST_ROOT/reset-missing-install"
+  local existing_install="$TEST_ROOT/reset-install-only"
+  local missing_data="$TEST_ROOT/reset-missing-data"
+  mkdir -p "$existing_data"
+
+  IS_ROOT=true
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_DIR="$missing_install"
+  HIVEKEEP_DATA_DIR="$existing_data"
+  setup_system_user &>/dev/null
+
+  assert_equal "$TEST_USER" "$(stat -c '%U' "$existing_data")" "reset data ownership"
+  [ ! -e "$missing_install" ] || fail "service-user setup created the missing install directory"
+
+  mkdir -p "$existing_install"
+  HIVEKEEP_DIR="$existing_install"
+  HIVEKEEP_DATA_DIR="$missing_data"
+  setup_system_user &>/dev/null
+
+  assert_equal "$TEST_USER" "$(stat -c '%U' "$existing_install")" "reset install ownership"
+  [ ! -e "$missing_data" ] || fail "service-user setup created the missing data directory"
+)
+test_setup_user_with_missing_install_dir
+pass "Reset preflight tolerates one missing installation path"
+
+test_unusable_bun_fails() (
+  local private_install="$PRIVATE_DIR/unusable"
+  local private_bun="$private_install/bin/bun"
+  local error_log="$TEST_ROOT/unusable-error.log"
+  mkdir -p "$(dirname "$private_bun")"
+  printf '%s\n' \
+    '#!/bin/sh' \
+    '[ "$(id -u)" -eq 0 ] || exit 42' \
+    'printf "1.3.14\n"' > "$private_bun"
+  chmod 0755 "$private_bun"
+  chmod 0700 "$PRIVATE_DIR"
+
+  IS_ROOT=true
+  OS=Linux
+  INIT_SYSTEM=systemd
+  HIVEKEEP_USER="$TEST_USER"
+  HIVEKEEP_SYSTEM_BUN_INSTALL="$TEST_ROOT/managed-unusable"
+  BUN_INSTALL="$private_install"
+  PATH="$private_install/bin:$ORIGINAL_PATH"
+
+  if (resolve_bun_path > /dev/null 2> "$error_log"); then
+    fail "unusable Bun passed service-user validation"
+  fi
+  grep -q "cannot execute as '$TEST_USER' after staging" "$error_log" || \
+    fail "unusable Bun failed for an unexpected reason"
+  if compgen -G "$HIVEKEEP_SYSTEM_BUN_INSTALL/bin/bun.tmp.*" > /dev/null; then
+    fail "failed Bun validation left a staged file behind"
+  fi
+)
+test_unusable_bun_fails
+pass "Resolution fails before service creation when Bun remains unusable"
+
+echo "All $pass_count installer Bun path tests passed."

--- a/tests/install-bun-path.sh
+++ b/tests/install-bun-path.sh
@@ -147,9 +147,11 @@ test_systemd_user_unit
 pass "Generated systemd user unit preserves and validates the Bun path"
 
 test_systemd_system_unit() (
-  local system_bun="$TEST_ROOT/system-runtime/bin/bun"
+  local system_bun="$TEST_ROOT/system%runtime/bin/bun"
   local system_unit="$TEST_ROOT/system-hivekeep.service"
   local systemctl_log="$TEST_ROOT/systemctl-calls"
+  local escaped_bun
+  local escaped_service_path
   local -a systemctl_calls
   make_bun "$system_bun"
   mkdir -p "$TEST_ROOT/system-app" "$TEST_ROOT/system-data"
@@ -166,9 +168,11 @@ test_systemd_system_unit() (
 
   grep -Fq "User=$TEST_USER" "$UNIT_FILE" || fail "systemd system unit lost its service user"
   grep -Fq "Group=$TEST_USER" "$UNIT_FILE" || fail "systemd system unit lost its service group"
-  grep -Fq "ExecStart=\"$system_bun\" src/server/index.ts" "$UNIT_FILE" || \
+  escaped_bun="$(escape_systemd_exec_token "$system_bun")"
+  grep -Fq "ExecStart=\"$escaped_bun\" src/server/index.ts" "$UNIT_FILE" || \
     fail "systemd system unit lost the verified Bun path"
-  grep -Fq "Environment=\"PATH=$(dirname "$system_bun"):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\"" "$UNIT_FILE" || \
+  escaped_service_path="$(escape_systemd_environment_value "$(dirname "$system_bun"):/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")"
+  grep -Fq "Environment=\"PATH=$escaped_service_path\"" "$UNIT_FILE" || \
     fail "systemd system unit lost the Bun service PATH"
   if command -v systemd-analyze &>/dev/null; then
     systemd-analyze verify "$UNIT_FILE" || fail "generated systemd system unit failed verification"


### PR DESCRIPTION
## Description

Root Linux installs could create `/usr/local/bin/bun` as a symlink to `/root/.bun/bin/bun` while the systemd service runs as the unprivileged `hivekeep` user. When `/root` is mode `0700`, systemd cannot traverse that path and the service fails with `203/EXEC`.

This change gives root Linux installs a fixed managed Bun location at `/usr/local/lib/hivekeep/bun`, verifies the selected executable as the service user, and copies an inaccessible Bun into that managed location without changing the legacy `/usr/local/bin/bun` link. The generated unit uses the verified absolute executable, receives the matching Bun directory in `PATH`, and resets a failed unit before starting so a repaired install is not blocked by systemd's start limit.

The installer also persists the verified root runtime in root-owned metadata, uses that metadata for root diagnostics, and runs Bun probes as `hivekeep` with a minimal environment. Non-root installs keep their normal user-local Bun behavior.

For existing v1.9 installs affected by #34, rerun the updated installer after this change is available. An updater process that started from the old installer cannot repair itself during that same run because it continues executing the old script.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / Build
- [x] Tests
- [ ] Breaking change
- [ ] Other

## Related Issues

Fixes #34

## How to Test

- [x] Unit tests (`bun test`)
- [x] Manual testing
- [ ] N/A (docs only)

Validation completed:

- `sudo bash tests/install-bun-path.sh`: all 14 installer regression cases passed
- `bash -n install.sh tests/install-bun-path.sh docker/entrypoint.sh`
- `shellcheck -S error install.sh tests/install-bun-path.sh`
- `bun run typecheck`
- Repository pre-commit suite: 3,985 passed, 109 skipped, 0 failed
- `bun run build`
- Live Ubuntu systemd smoke test: active and running, nonzero main PID, zero execution status, and Bun 1.3.14 executed as the service user
- Live start-limit reproduction confirmed that `daemon-reload` alone does not clear `Start request repeated too quickly`; the service creation path now resets the failed state before starting, with command-order regression coverage

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I've tested this locally
- [x] The build passes (`bun run build`)
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] New code follows existing patterns and conventions
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated documentation if needed
- [ ] User-facing strings use `useTranslation()` with keys in both `en.json` and `fr.json`
- [ ] No hardcoded colors - uses semantic CSS variables or Tailwind tokens
- [ ] Shared types in `src/shared/types.ts`, shared constants in `src/shared/constants.ts`
- [ ] Breaking changes are noted above (if any)
